### PR TITLE
🧹 [code health improvement] Remove Leftover Debug Console Log 2

### DIFF
--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -824,7 +824,6 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       // 2. Validate Target & Insert
       if (targetId === "root") {
-        console.log("[moveNode] Dropping at root");
         return { files: [...newFilesWithoutSource, detachedNode!] };
       }
 


### PR DESCRIPTION
Removed a leftover debug console log `console.log("[moveNode] Dropping at root");` from `src/store/useAppStore.ts`. This improves code cleanliness and maintainability by removing unnecessary output in production environments.

---
*PR created automatically by Jules for task [942552229934959882](https://jules.google.com/task/942552229934959882) started by @7sg56*