### PR TITLE
🔒 [security fix] Add rehype-sanitize to MarkdownPreview

### DIFF
--- a/src/components/layout/editor/MarkdownPreview.tsx
+++ b/src/components/layout/editor/MarkdownPreview.tsx
@@ -3,6 +3,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import rehypeHighlight from 'rehype-highlight';
+import rehypeSanitize from 'rehype-sanitize';
 import { processMarkdown } from '../../../util/markdownpipeline';
 
 // CSS imports
@@ -21,7 +22,7 @@ export function MarkdownPreview({ content }: MarkdownPreviewProps) {
         <div className="markdown-preview flex-1 w-full h-full px-12 py-10 overflow-y-auto">
             <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
-                rehypePlugins={[rehypeKatex, rehypeHighlight]}
+                rehypePlugins={[rehypeSanitize, rehypeKatex, rehypeHighlight]}
             >
                 {processed}
             </ReactMarkdown>


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential Cross-Site Scripting (XSS) risk in the markdown rendering component.
⚠️ **Risk:** Without sanitization, malicious markdown content could execute arbitrary JavaScript in the user's browser, potentially leading to data theft or unauthorized actions.
🛡️ **Solution:** Integrated `rehype-sanitize` into the `ReactMarkdown` plugin pipeline. The plugin is positioned before `rehype-katex` and `rehype-highlight` to allow for secure sanitization while preserving the functionality of math rendering and code syntax highlighting.

---
*PR created automatically by Jules for task [5032485024044842124](https://jules.google.com/task/5032485024044842124) started by @7sg56*