### PR TITLE
🧹 Code Health: Remove Leftover Debug Log from moveNode

### DIFF
--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -791,7 +791,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       const files = [...state.files];
 
       // 1. Find and Remove Source
-      console.log(`[moveNode] Moving ${sourceId} -> ${targetId} (${position})`);
       let detachedNode: FileNode | null = null;
 
       const removeNode = (nodes: FileNode[]): FileNode[] => {


### PR DESCRIPTION
🎯 **What:** Removed a leftover debug `console.log` statement from the `moveNode` function in `src/store/useAppStore.ts`.
💡 **Why:** This log is unnecessary debug output that clutter the console and is not needed in production code. Removing it cleans up the codebase and improves readability.
✅ **Verification:** Ran `npm run lint` and `npm run typecheck` to ensure no errors were introduced. Requested code review to verify the exact change and reverted unintended changes to `package-lock.json` caused by `npm install`.
✨ **Result:** The code is cleaner, removing extraneous console noise without affecting functionality.

---
*PR created automatically by Jules for task [11746441280054413056](https://jules.google.com/task/11746441280054413056) started by @7sg56*