### PR TITLE
🧹 Remove Leftover Debug Console Log in useAppStore

### DIFF
--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -842,7 +842,6 @@ export const useAppStore = create<AppState>((set, get) => ({
 
         for (const node of list) {
           if (node.id === targetId) {
-            console.log("[moveNode] Target found:", node.id);
             inserted = true;
             // Prepare node to insert (detachedNode)
             // We don't check name collision here optimally but let's assume UI handles it or we fix it later


### PR DESCRIPTION
🎯 **What:** Removed `console.log('[moveNode] Target found:', node.id);` from the `moveNode` action in `src/store/useAppStore.ts`.

💡 **Why:** This leftover debug statement pollutes the console and is unnecessary for production use, improving code cleanliness and maintainability.

✅ **Verification:** Verified by running `npm run typecheck` and `npm run lint`, both of which passed, indicating no regressions in functionality.

✨ **Result:** The application state management code is slightly cleaner and generates less noise in the developer console.

---
*PR created automatically by Jules for task [17120048889707401944](https://jules.google.com/task/17120048889707401944) started by @7sg56*