### PR TITLE
🧹 [Code Health] Remove Leftover Error Console Log in useAppStore

### DIFF
--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -818,7 +818,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       const newFilesWithoutSource = removeNode(files);
 
       if (!detachedNode) {
-        console.error("[moveNode] Source node not found:", sourceId);
         return {};
       }
 


### PR DESCRIPTION
🎯 **What:** Removed leftover debug code `console.error('[moveNode] Source node not found:', sourceId);` in `src/store/useAppStore.ts`.
💡 **Why:** This improves maintainability and cleans up console output, as the early return condition correctly handles the edge case without needing an error log intended for debugging during development.
✅ **Verification:** Ran `npm run lint` and `npm run typecheck` to confirm no type errors or regressions. Code review verified that this only removes an unnecessary console log and does not change functionality.
✨ **Result:** Cleaned up code by removing noise in the console.

---
*PR created automatically by Jules for task [8738585684767611240](https://jules.google.com/task/8738585684767611240) started by @7sg56*