### PR TITLE
feat: implement search and find files functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@codemirror/commands": "^6.10.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
+        "@codemirror/search": "^6.6.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
@@ -2652,7 +2653,6 @@
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3398,7 +3398,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -6317,7 +6316,6 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
+    "@codemirror/search": "^6.6.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,8 +7,17 @@
 
 use crate::types::FileEntry;
 use crate::workspace::{scan_directory_recursive, validate_workspace_path};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub file_path: String,
+    pub file_name: String,
+    pub line_number: usize,
+    pub content_preview: String,
+}
 
 /// Scan a workspace directory and return the file tree
 /// 
@@ -132,4 +141,74 @@ pub fn create_folder(path: String) -> Result<(), String> {
 pub fn delete_folder(path: String) -> Result<(), String> {
     fs::remove_dir_all(&path)
         .map_err(|e| format!("Failed to delete folder '{}': {}", path, e))
+}
+
+/// Search workspace for a query string
+/// 
+/// # Arguments
+/// * `path` - Absolute path to the workspace directory
+/// * `query` - Search string
+/// 
+/// # Returns
+/// * `Ok(Vec<SearchResult>)` - List of matching files and snippets
+/// * `Err(String)` - Error message if scan fails
+#[tauri::command]
+pub fn search_workspace(path: String, query: String) -> Result<Vec<SearchResult>, String> {
+    let workspace_path = Path::new(&path);
+    validate_workspace_path(workspace_path)?;
+    
+    let mut results = Vec::new();
+    let query_lower = query.to_lowercase();
+    
+    fn search_dir(dir: &Path, query_lower: &str, results: &mut Vec<SearchResult>) {
+        let read_dir = match fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(_) => return, // ignore unreadable directories
+        };
+        for entry in read_dir {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            
+            if file_name.starts_with('.') {
+                continue;
+            }
+            
+            // Check if it's a directory (ignore errors)
+            if let Ok(metadata) = entry.metadata() {
+                if metadata.is_dir() {
+                    search_dir(&path, query_lower, results);
+                } else if file_name.ends_with(".md") {
+                    // Check if file name itself matches
+                    if file_name.to_lowercase().contains(query_lower) {
+                        results.push(SearchResult {
+                            file_path: path.to_string_lossy().to_string(),
+                            file_name: file_name.clone(),
+                            line_number: 1, // Using 1 for title match
+                            content_preview: "Matches file name".to_string(),
+                        });
+                    }
+
+                    if let Ok(content) = fs::read_to_string(&path) {
+                        for (i, line) in content.lines().enumerate() {
+                            if line.to_lowercase().contains(query_lower) {
+                                results.push(SearchResult {
+                                    file_path: path.to_string_lossy().to_string(),
+                                    file_name: file_name.clone(),
+                                    line_number: i + 1,
+                                    content_preview: line.trim().to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    search_dir(workspace_path, &query_lower, &mut results);
+    Ok(results)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run() {
             commands::rename_note,
             commands::create_folder,
             commands::delete_folder,
+            commands::search_workspace,
         ])
         .setup(|app| {
             // Build a custom app menu without Cmd+W (Close Window)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { MainLayout } from "./components/layout/MainLayout";
 import { FileExplorer } from "./components/layout/explorer/FileExplorer";
 import { EditorPane } from "./components/layout/editor/EditorPane";
 import { FloatingHub } from "./components/features/FloatingHub";
+import { SearchPanel } from "./components/features/SearchPanel";
 import { WorkspaceWelcome } from "./components/onboarding/WorkspaceWelcome";
 import { useAppStore } from "./store/useAppStore";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
@@ -25,6 +26,7 @@ function App() {
         editorContent={<EditorPane />}
       />
       <FloatingHub />
+      <SearchPanel />
     </>
   );
 }

--- a/src/components/features/SearchPanel.tsx
+++ b/src/components/features/SearchPanel.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAppStore, type SearchResult } from "../../store/useAppStore";
+import { Search, FileText, X } from "lucide-react";
+
+export function SearchPanel() {
+  const {
+    isSearchOpen,
+    searchQuery,
+    searchResults,
+    workspacePath,
+    setSearchOpen,
+    setSearchQuery,
+    setSearchResults,
+    selectFile,
+  } = useAppStore();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when modal opens
+  useEffect(() => {
+    if (isSearchOpen) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [isSearchOpen]);
+
+  // Handle actual search backend call
+  const handleSearch = useCallback(
+    async (query: string) => {
+      if (!query.trim() || !workspacePath) {
+        setSearchResults([]);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const results = await invoke<SearchResult[]>("search_workspace", {
+          path: workspacePath,
+          query: query.trim(),
+        });
+        setSearchResults(results);
+      } catch (error) {
+        console.error("Search failed:", error);
+        setSearchResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [workspacePath, setSearchResults],
+  );
+
+  // Debounce user input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      handleSearch(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, handleSearch]);
+
+  if (!isSearchOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-black/40 backdrop-blur-sm"
+      onClick={() => setSearchOpen(false)}
+    >
+      <div
+        className="w-full max-w-2xl bg-[#1e1e1e] border border-white/10 rounded-xl shadow-2xl flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center px-4 py-3 border-b border-white/10">
+          <Search className="w-5 h-5 text-gray-400 mr-3" />
+          <input
+            ref={inputRef}
+            type="text"
+            className="flex-1 bg-transparent text-white placeholder-gray-500 outline-none text-lg"
+            placeholder="Search workspace..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setSearchOpen(false);
+              }
+            }}
+          />
+          {isLoading && (
+            <div className="w-4 h-4 border-2 border-[#1e90ff] border-t-transparent rounded-full animate-spin ml-3"></div>
+          )}
+          <button
+            className="p-1 hover:bg-white/10 rounded ml-2"
+            onClick={() => setSearchOpen(false)}
+          >
+            <X className="w-5 h-5 text-gray-400" />
+          </button>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto">
+          {searchResults.length > 0 ? (
+            <div className="p-2 space-y-1">
+              {searchResults.map((result, i) => (
+                <button
+                  key={`${result.file_path}-${result.line_number}-${i}`}
+                  className="w-full flex items-start text-left p-3 hover:bg-white/5 rounded-lg group transition-colors"
+                  onClick={() => {
+                    selectFile(result.file_path);
+                    setSearchOpen(false);
+                  }}
+                >
+                  <FileText className="w-4 h-4 text-gray-400 mt-1 mr-3 group-hover:text-blue-400 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center space-x-2">
+                      <span className="text-sm font-medium text-gray-200 truncate">
+                        {result.file_name}
+                      </span>
+                      <span className="text-xs text-gray-500">
+                        Line {result.line_number}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-400 truncate mt-1">
+                      {result.content_preview}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          ) : searchQuery.trim().length > 0 && !isLoading ? (
+            <div className="p-8 text-center text-gray-500">
+              No results found for "{searchQuery}"
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/editor/CodeMirrorEditor.tsx
+++ b/src/components/layout/editor/CodeMirrorEditor.tsx
@@ -17,6 +17,8 @@ import { EditorView, type ViewUpdate } from "@codemirror/view";
 import { cinderTheme } from "../../../theme/cinderTheme";
 import { markdownStylingPlugin } from "./markdownStylingPlugin";
 
+import { search } from "@codemirror/search";
+
 interface CodeMirrorEditorProps {
   /** Current file content */
   value: string;
@@ -37,6 +39,7 @@ const extensions = [
   }),
   EditorView.lineWrapping,
   markdownStylingPlugin,
+  search(),
 ];
 
 export function CodeMirrorEditor({

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -18,6 +18,8 @@ export function useKeyboardShortcuts() {
     closeFile,
     toggleExplorerCollapsed,
     createFolder,
+    isSearchOpen,
+    setSearchOpen,
   } = useAppStore();
 
   useEffect(() => {
@@ -69,6 +71,25 @@ export function useKeyboardShortcuts() {
           toggleExplorerCollapsed();
           break;
         }
+
+        // Cmd+F or Cmd+Shift+F -- Global search or local search
+        case "f": {
+          if (e.shiftKey) {
+            e.preventDefault();
+            setSearchOpen(!isSearchOpen);
+          } else {
+            // If it's just Cmd+F, check if we're focused in the editor
+            const activeEl = document.activeElement;
+            const isEditorFocused = activeEl?.closest('.cm-editor') !== null;
+            
+            if (!isEditorFocused) {
+              e.preventDefault();
+              setSearchOpen(!isSearchOpen);
+            }
+            // else let CodeMirror handle its native search
+          }
+          break;
+        }
       }
     };
 
@@ -82,5 +103,7 @@ export function useKeyboardShortcuts() {
     closeFile,
     toggleExplorerCollapsed,
     createFolder,
+    isSearchOpen,
+    setSearchOpen,
   ]);
 }

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -2,6 +2,13 @@ import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
 import type { FileNode } from "../types/fileSystem";
 
+export interface SearchResult {
+  file_path: string;
+  file_name: string;
+  line_number: number;
+  content_preview: string;
+}
+
 interface AppState {
   files: FileNode[];
   workspacePath: string | null;
@@ -18,10 +25,20 @@ interface AppState {
   pendingFileId: string | null;
   isAutoSave: boolean;
 
+  // Search State
+  isSearchOpen: boolean;
+  searchQuery: string;
+  searchResults: SearchResult[];
+
   // Workspace Actions
   setWorkspacePath: (path: string | null) => void;
   setFiles: (files: FileNode[]) => void;
   resetWorkspace: () => void;
+
+  // Search Actions
+  setSearchOpen: (isOpen: boolean) => void;
+  setSearchQuery: (query: string) => void;
+  setSearchResults: (results: SearchResult[]) => void;
 
   // Actions
   selectFile: (fileId: string) => void;
@@ -79,8 +96,16 @@ export const useAppStore = create<AppState>((set, get) => ({
   expandedFolderIds: [],
   isAutoSave: true,
 
+  isSearchOpen: false,
+  searchQuery: "",
+  searchResults: [],
+
   // Workspace actions
   setWorkspacePath: (path: string | null) => set({ workspacePath: path }),
+
+  setSearchOpen: (isOpen: boolean) => set({ isSearchOpen: isOpen }),
+  setSearchQuery: (query: string) => set({ searchQuery: query }),
+  setSearchResults: (results: SearchResult[]) => set({ searchResults: results }),
 
   setFiles: (files: FileNode[]) =>
     set({


### PR DESCRIPTION
Global Search UI: Added a new SearchPanel (toggled via Cmd+Shift+F) to search text across the workspace, showing file paths, line numbers, and content previews.
Backend Search: Added a search_workspace Tauri command in Rust to quickly scan workspace files, ignoring .gitignore files.
In-Editor Search: Enabled local file search via Cmd+F by adding the @codemirror/search package to the editor.
Keyboard Shortcuts: Configured smart keyboard shortcuts that map Cmd+F to editor search if focused there, and to global search otherwise. Added Cmd+Shift+F for explicit global search.