### PR TITLE
feat: implement pinned notes feature and clean up settings UI

### DIFF
--- a/src/components/features/settings/Settings.tsx
+++ b/src/components/features/settings/Settings.tsx
@@ -9,7 +9,6 @@ import {
   Bell,
   FolderOpen,
   Globe,
-  Save,
   ChevronDown,
 } from 'lucide-react';
 
@@ -200,31 +199,6 @@ export function Settings() {
                     Editor
                   </h2>
                   <div className="space-y-3">
-                    <div className="flex items-center justify-between p-4 bg-[var(--bg-secondary)] rounded-lg border border-[var(--border-primary)] opacity-60">
-                      <div className="flex items-center gap-4">
-                        <div className="p-2 bg-[var(--bg-tertiary)] rounded-md text-[var(--text-secondary)]">
-                          <Save size={20} />
-                        </div>
-                        <div>
-                          <h3 className="text-sm font-medium text-[var(--text-primary)] flex items-center gap-2">
-                            Auto-save
-                            <span className="text-[10px] font-bold uppercase tracking-wider bg-[var(--bg-tertiary)] border border-[var(--border-primary)] text-[var(--text-secondary)] px-1.5 py-0.5 rounded">
-                              Coming Soon
-                            </span>
-                          </h3>
-                          <p className="text-xs text-[var(--text-secondary)] mt-0.5">
-                            Automatically save changes while typing
-                          </p>
-                        </div>
-                      </div>
-                      <button
-                        disabled
-                        className="w-10 h-6 bg-[var(--bg-tertiary)] border border-[var(--border-primary)] rounded-full relative cursor-not-allowed"
-                      >
-                        <div className="w-4 h-4 bg-[var(--text-tertiary)] rounded-full absolute left-1 top-[3px]" />
-                      </button>
-                    </div>
-
                     {[
                       {
                         icon: Monitor,

--- a/src/components/layout/editor/EditorTabs.tsx
+++ b/src/components/layout/editor/EditorTabs.tsx
@@ -32,6 +32,7 @@ export function EditorTabs() {
     createFolder,
     closeOtherFiles,
     closeAllFiles,
+    togglePin,
   } = useAppStore();
 
   return (
@@ -78,6 +79,7 @@ export function EditorTabs() {
                   closeOtherFiles,
                   closeAllFiles,
                   findFile,
+                  togglePin,
                 });
               }}
               className={`group flex items-center min-w-[140px] max-w-[220px] h-full px-4 border-r cursor-pointer text-[12px] font-medium select-none transition-all relative shrink-0`}

--- a/src/components/layout/explorer/FileExplorer.tsx
+++ b/src/components/layout/explorer/FileExplorer.tsx
@@ -50,6 +50,8 @@ export function FileExplorer() {
     closeOtherFiles,
     closeAllFiles,
     findFile,
+    togglePin,
+    pinnedFiles,
   } = useAppStore();
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -156,6 +158,7 @@ export function FileExplorer() {
               closeOtherFiles,
               closeAllFiles,
               findFile,
+              togglePin,
             });
           }
         }}
@@ -166,6 +169,37 @@ export function FileExplorer() {
           </div>
         ) : (
           <div>
+            {/* Pinned Files Section */}
+            {!searchQuery.trim() && pinnedFiles.length > 0 && (
+              <div className="mb-2">
+                <div className="px-2 py-1 flex items-center gap-1.5 opacity-60">
+                  <span className="text-[10px] font-bold tracking-wider uppercase">
+                    Pinned Notes
+                  </span>
+                </div>
+                {pinnedFiles.map((fileId) => {
+                  const node = findFile(fileId, files);
+                  // Ignore nodes that no longer exist
+                  if (!node) return null;
+                  return (
+                    <FileTreeItem
+                      key={`pinned-${node.id}`}
+                      node={node}
+                      isPinnedItem
+                    />
+                  );
+                })}
+              </div>
+            )}
+
+            {!searchQuery.trim() && pinnedFiles.length > 0 && (
+              <div className="px-2 py-1 flex items-center gap-1.5 opacity-60 mt-1">
+                <span className="text-[10px] font-bold tracking-wider uppercase">
+                  All Notes
+                </span>
+              </div>
+            )}
+
             {filteredFiles.map((node) => (
               <FileTreeItem key={node.id} node={node} />
             ))}

--- a/src/components/layout/explorer/FileTreeItem.tsx
+++ b/src/components/layout/explorer/FileTreeItem.tsx
@@ -56,9 +56,14 @@ function RenameInput({ initialValue, onRename, onCancel }: RenameInputProps) {
 interface FileTreeItemProps {
   node: FileNode;
   depth?: number;
+  isPinnedItem?: boolean;
 }
 
-export function FileTreeItem({ node, depth = 0 }: FileTreeItemProps) {
+export function FileTreeItem({
+  node,
+  depth = 0,
+  isPinnedItem = false,
+}: FileTreeItemProps) {
   const {
     openFileInNewTab,
     activeFileId,
@@ -80,6 +85,7 @@ export function FileTreeItem({ node, depth = 0 }: FileTreeItemProps) {
     closeAllFiles,
     createFile,
     findFile,
+    togglePin,
   } = useAppStore();
 
   // Derived state from store
@@ -230,6 +236,7 @@ export function FileTreeItem({ node, depth = 0 }: FileTreeItemProps) {
       closeOtherFiles,
       closeAllFiles,
       findFile,
+      togglePin,
     };
     if (node.type === 'folder') {
       showFolderContextMenu(node, actions);
@@ -271,12 +278,12 @@ export function FileTreeItem({ node, depth = 0 }: FileTreeItemProps) {
           onClick={handleClick}
           onDoubleClick={handleDoubleClick}
           onContextMenu={handleContextMenu}
-          draggable={!isRenaming}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
+          draggable={!isRenaming && !isPinnedItem}
+          onDragStart={!isPinnedItem ? handleDragStart : undefined}
+          onDragEnd={!isPinnedItem ? handleDragEnd : undefined}
+          onDragOver={!isPinnedItem ? handleDragOver : undefined}
+          onDragLeave={!isPinnedItem ? handleDragLeave : undefined}
+          onDrop={!isPinnedItem ? handleDrop : undefined}
           style={{
             paddingLeft,
             // Background logic: Active gets priority, but drag 'inside' overrides it
@@ -338,7 +345,7 @@ export function FileTreeItem({ node, depth = 0 }: FileTreeItemProps) {
         </div>
       </div>
 
-      {node.type === 'folder' && isOpen && node.children && (
+      {node.type === 'folder' && isOpen && node.children && !isPinnedItem && (
         <div className="">
           {node.children.map((child) => (
             <FileTreeItem key={child.id} node={child} depth={depth + 1} /> // Recursive rendering

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
 import type { FileNode } from '../types/fileSystem';
 
@@ -24,6 +25,7 @@ interface AppState {
   expandedFolderIds: string[]; // List of folder IDs that are expanded
   pendingFileId: string | null;
   isAutoSave: boolean;
+  pinnedFiles: string[];
 
   // Search State
   isSearchOpen: boolean;
@@ -69,6 +71,7 @@ interface AppState {
     position: 'inside' | 'before' | 'after' | 'root'
   ) => void;
   toggleAutoSave: () => void;
+  togglePin: (fileId: string) => void;
   openSystemTab: (tabId: string) => void;
 
   // Context Menu Actions
@@ -81,1198 +84,1247 @@ interface AppState {
   closeAllFiles: () => void;
 }
 
-export const useAppStore = create<AppState>((set, get) => ({
-  files: [],
-  workspacePath: null,
-  activeFileId: null,
-  openFiles: [],
-  activeFileContent: '',
-  isExplorerCollapsed: false,
-  newTabCounter: 0,
-  renamingFileId: null,
-  renameSource: null,
-  pendingFileId: null,
-  lastSidebarWidth: 20,
-  expandedFolderIds: [],
-  isAutoSave: true,
-
-  isSearchOpen: false,
-  searchQuery: '',
-  searchResults: [],
-
-  // Workspace actions
-  setWorkspacePath: (path: string | null) => set({ workspacePath: path }),
-
-  setSearchOpen: (isOpen: boolean) => set({ isSearchOpen: isOpen }),
-  setSearchQuery: (query: string) => set({ searchQuery: query }),
-  setSearchResults: (results: SearchResult[]) =>
-    set({ searchResults: results }),
-
-  setFiles: (files: FileNode[]) =>
-    set({
-      files,
-      activeFileId: null,
-      openFiles: [],
-      activeFileContent: '',
-      expandedFolderIds: [],
-    }),
-
-  resetWorkspace: () =>
-    set({
+export const useAppStore = create<AppState>()(
+  persist(
+    (set, get) => ({
       files: [],
       workspacePath: null,
       activeFileId: null,
       openFiles: [],
       activeFileContent: '',
-      expandedFolderIds: [],
-    }),
-
-  findFile: (id: string, nodes = get().files): FileNode | null => {
-    for (const node of nodes) {
-      if (node.id === id) return node;
-      if (node.children) {
-        const found = get().findFile(id, node.children);
-        if (found) return found;
-      }
-    }
-    return null;
-  },
-
-  getFileBreadcrumb: (fileId: string): FileNode[] => {
-    const breadcrumb: FileNode[] = [];
-
-    const traverse = (nodes: FileNode[]): boolean => {
-      for (const node of nodes) {
-        breadcrumb.push(node);
-        if (node.id === fileId) {
-          return true;
-        }
-        if (node.children && traverse(node.children)) {
-          return true;
-        }
-        breadcrumb.pop();
-      }
-      return false;
-    };
-
-    traverse(get().files);
-    return breadcrumb;
-  },
-
-  selectFile: (fileId: string) => {
-    // Handle blank tabs
-    if (fileId.startsWith('new-tab-')) {
-      set((state) => {
-        // If currently on welcome page, replace it
-        if (state.activeFileId === 'welcome') {
-          return {
-            activeFileId: fileId,
-            activeFileContent: '',
-            openFiles: [fileId], // Replace welcome entirely
-          };
-        }
-        return {
-          activeFileId: fileId,
-          activeFileContent: '',
-        };
-      });
-      return;
-    }
-
-    // Handle System Tabs
-    if (fileId.startsWith('cinder-')) {
-      set({ activeFileId: fileId, activeFileContent: '' });
-      return;
-    }
-
-    const file = get().findFile(fileId);
-    if (file && file.type === 'file') {
-      const { openFiles, activeFileId } = get();
-      const filePath = file.path;
-
-      // Helper to update state with content
-      const updateWithContent = (content: string) => {
-        const currentState = get();
-        const currentActiveId = currentState.activeFileId;
-
-        // If currently on a blank tab OR welcome tab, replace it
-        if (
-          currentActiveId &&
-          (currentActiveId.startsWith('new-tab-') ||
-            currentActiveId === 'welcome')
-        ) {
-          const newOpenFiles = currentState.openFiles.map((id) =>
-            id === currentActiveId ? fileId : id
-          );
-          set({
-            activeFileId: fileId,
-            activeFileContent: content,
-            openFiles: newOpenFiles,
-          });
-        } else {
-          // Otherwise, open in new tab if not already open
-          const needsToOpen = !currentState.openFiles.includes(fileId);
-          set({
-            activeFileId: fileId,
-            activeFileContent: content,
-            openFiles: needsToOpen
-              ? [...currentState.openFiles, fileId]
-              : currentState.openFiles,
-          });
-        }
-      };
-
-      // If file has a path, read from disk
-      if (filePath) {
-        // Set as active immediately with loading state
-        if (
-          activeFileId &&
-          (activeFileId.startsWith('new-tab-') || activeFileId === 'welcome')
-        ) {
-          const newOpenFiles = openFiles.map((id) =>
-            id === activeFileId ? fileId : id
-          );
-          set({
-            activeFileId: fileId,
-            openFiles: newOpenFiles,
-            activeFileContent: '',
-          });
-        } else {
-          const needsToOpen = !openFiles.includes(fileId);
-          set({
-            activeFileId: fileId,
-            openFiles: needsToOpen ? [...openFiles, fileId] : openFiles,
-            activeFileContent: '',
-          });
-        }
-
-        // Read content from disk
-        invoke<string>('read_note', { path: filePath })
-          .then((content) => {
-            // Only update if this file is still active
-            if (get().activeFileId === fileId) {
-              set({ activeFileContent: content });
-            }
-          })
-          .catch((err) => {
-            console.error('Failed to read file:', err);
-            set({ activeFileContent: `Error loading file: ${err}` });
-          });
-      } else {
-        // Fallback to in-memory content
-        updateWithContent(file.content || '');
-      }
-    }
-  },
-
-  openSystemTab: (tabId: string) => {
-    const { openFiles, activeFileId } = get();
-
-    // If already open, just select it
-    if (openFiles.includes(tabId)) {
-      set({ activeFileId: tabId, activeFileContent: '' });
-      return;
-    }
-
-    // If currently on welcome/blank, replace it
-    if (
-      activeFileId &&
-      (activeFileId === 'welcome' || activeFileId.startsWith('new-tab-'))
-    ) {
-      const newOpenFiles = openFiles.map((id) =>
-        id === activeFileId ? tabId : id
-      );
-      set({
-        activeFileId: tabId,
-        openFiles: newOpenFiles,
-        activeFileContent: '',
-      });
-    } else {
-      // Append
-      set({
-        activeFileId: tabId,
-        openFiles: [...openFiles, tabId],
-        activeFileContent: '',
-      });
-    }
-  },
-
-  openFileInNewTab: (fileId: string) => {
-    const file = get().findFile(fileId);
-    if (file && file.type === 'file') {
-      const { openFiles, activeFileId } = get();
-      const filePath = file.path;
-
-      // Set as active immediately
-      if (
-        activeFileId &&
-        (activeFileId.startsWith('new-tab-') || activeFileId === 'welcome')
-      ) {
-        const newOpenFiles = openFiles.map((id) =>
-          id === activeFileId ? fileId : id
-        );
-        set({
-          activeFileId: fileId,
-          openFiles: newOpenFiles,
-          activeFileContent: '',
-        });
-      } else {
-        const needsToOpen = !openFiles.includes(fileId);
-        set({
-          activeFileId: fileId,
-          openFiles: needsToOpen ? [...openFiles, fileId] : openFiles,
-          activeFileContent: '',
-        });
-      }
-
-      // If file has a path, read from disk
-      if (filePath) {
-        invoke<string>('read_note', { path: filePath })
-          .then((content) => {
-            if (get().activeFileId === fileId) {
-              set({ activeFileContent: content });
-            }
-          })
-          .catch((err) => {
-            console.error('Failed to read file:', err);
-            set({ activeFileContent: `Error loading file: ${err}` });
-          });
-      } else {
-        // Fallback to in-memory content
-        set({ activeFileContent: file.content || '' });
-      }
-    }
-  },
-
-  closeFile: (fileId: string) => {
-    const { openFiles, activeFileId } = get();
-    const newOpenFiles = openFiles.filter((id) => id !== fileId);
-
-    if (activeFileId === fileId) {
-      const nextActive =
-        newOpenFiles.length > 0 ? newOpenFiles[newOpenFiles.length - 1] : null;
-      if (nextActive) {
-        get().selectFile(nextActive);
-      } else {
-        set({ activeFileId: null, activeFileContent: '' });
-        // If we closed the last tab, we might want to show empty state or Welcome?
-        // For now, empty state is fine.
-      }
-    }
-
-    set({ openFiles: newOpenFiles });
-  },
-
-  updateFileContent: (fileId: string, content: string) => {
-    const state = get();
-    const { workspacePath } = state;
-
-    // Handle deferred creation for new tabs
-    if (fileId.startsWith('new-tab-')) {
-      if (!workspacePath) {
-        console.error('No workspace path set');
-        return;
-      }
-
-      const { files, openFiles } = state;
-
-      // Find a unique name
-      let nameCounter = 0;
-      const baseName = 'untitled';
-      const extension = '.md';
-      let newName = `${baseName}${extension}`;
-
-      const checkNameExists = (name: string, nodes: FileNode[]): boolean => {
-        for (const node of nodes) {
-          if (node.name === name) return true;
-          if (node.children && checkNameExists(name, node.children))
-            return true;
-        }
-        return false;
-      };
-
-      while (checkNameExists(newName, files)) {
-        nameCounter++;
-        newName = `${baseName}-${nameCounter}${extension}`;
-      }
-
-      const filePath = `${workspacePath}/${newName}`;
-      const newFileId = filePath;
-
-      const newFile: FileNode = {
-        id: newFileId,
-        name: newName,
-        type: 'file',
-        path: filePath,
-        content: content,
-      };
-
-      // Create file on disk with content
-      invoke('write_note', { path: filePath, content })
-        .then(() => console.log('File created on disk:', filePath))
-        .catch((err) => console.error('Failed to create file:', err));
-
-      const newFiles = [...files, newFile];
-      const newOpenFiles = openFiles.map((id) =>
-        id === fileId ? newFileId : id
-      );
-
-      set({
-        files: newFiles,
-        activeFileId: newFileId,
-        openFiles: newOpenFiles,
-        activeFileContent: content,
-      });
-      return;
-    }
-
-    // Find the file to get its path
-    const file = state.findFile(fileId);
-    const filePath = file?.path;
-
-    // Write to disk if we have a path
-    if (filePath) {
-      invoke('write_note', { path: filePath, content })
-        .then(() => console.log('File saved:', filePath))
-        .catch((err) => console.error('Failed to save file:', err));
-    }
-
-    // Normal update - Persist to store AND active state
-    set((state) => {
-      const updateContentRecursive = (nodes: FileNode[]): FileNode[] => {
-        return nodes.map((node) => {
-          if (node.id === fileId) {
-            return { ...node, content };
-          }
-          if (node.children) {
-            return { ...node, children: updateContentRecursive(node.children) };
-          }
-          return node;
-        });
-      };
-
-      return {
-        activeFileContent:
-          state.activeFileId === fileId ? content : state.activeFileContent,
-        files: updateContentRecursive(state.files),
-      };
-    });
-  },
-
-  toggleExplorerCollapsed: () => {
-    set((state) => {
-      const willExpand = state.isExplorerCollapsed;
-      let newWidth = state.sidebarWidth;
-
-      // If expanding and current width is too small (e.g. it was dragged to collapse boundary)
-      // Restore to last good size
-      if (willExpand && newWidth < 20) {
-        newWidth = state.lastSidebarWidth || 20;
-      }
-
-      return {
-        isExplorerCollapsed: !state.isExplorerCollapsed,
-        sidebarWidth: newWidth,
-      };
-    });
-  },
-
-  setExplorerCollapsed: (isCollapsed: boolean) => {
-    set((state) => {
-      // If manual set to expanded, also check width
-      if (!isCollapsed && state.sidebarWidth < 20) {
-        return {
-          isExplorerCollapsed: isCollapsed,
-          sidebarWidth: state.lastSidebarWidth || 20,
-        };
-      }
-      return { isExplorerCollapsed: isCollapsed };
-    });
-  },
-
-  sidebarWidth: 20,
-  setSidebarWidth: (width: number) => {
-    set((state) => ({
-      sidebarWidth: width,
-      lastSidebarWidth: width >= 20 ? width : state.lastSidebarWidth,
-    }));
-  },
-
-  createNewTab: () => {
-    set((state) => {
-      const newCounter = state.newTabCounter + 1;
-      const newTabId = `new-tab-${newCounter}`;
-
-      // If currently on welcome, replace it
-      if (state.activeFileId === 'welcome') {
-        return {
-          newTabCounter: newCounter,
-          activeFileId: newTabId,
-          openFiles: [newTabId],
-          activeFileContent: '',
-          renamingFileId: null, // Don't rename yet
-          renameSource: null,
-        };
-      }
-
-      return {
-        newTabCounter: newCounter,
-        activeFileId: newTabId,
-        openFiles: [...state.openFiles, newTabId],
-        activeFileContent: '',
-        renamingFileId: newTabId,
-        renameSource: 'editor',
-      };
-    });
-  },
-
-  createFile: () => {
-    // Creates file in tree immediately with rename mode active
-    // Also creates it on disk immediately
-    const state = get();
-    const { files, openFiles, workspacePath } = state;
-
-    if (!workspacePath) {
-      console.error('No workspace path set');
-      return;
-    }
-
-    // Generate unique name
-    let nameCounter = 0;
-    const baseName = 'New File';
-    const extension = '.md';
-    let newName = `${baseName}${extension}`;
-
-    const checkNameExists = (name: string, nodes: FileNode[]): boolean => {
-      for (const node of nodes) {
-        if (node.name === name) return true;
-      }
-      return false;
-    };
-
-    while (checkNameExists(newName, files)) {
-      nameCounter++;
-      newName = `${baseName} ${nameCounter}${extension}`;
-    }
-
-    const filePath = `${workspacePath}/${newName}`;
-    const newFileId = filePath; // Use path as ID for consistency
-
-    const newFile: FileNode = {
-      id: newFileId,
-      name: newName,
-      type: 'file',
-      path: filePath,
-      content: '',
-    };
-
-    // Create file on disk
-    invoke('create_note', { path: filePath })
-      .then(() => {
-        console.log('File created on disk:', filePath);
-      })
-      .catch((err) => {
-        console.error('Failed to create file on disk:', err);
-      });
-
-    // Add to file tree at root level
-    const newFiles = [...files, newFile];
-    const newOpenFiles = [...openFiles, newFileId];
-
-    set({
-      files: newFiles,
-      activeFileId: newFileId,
-      openFiles: newOpenFiles,
-      activeFileContent: '',
-      renamingFileId: newFileId,
-      pendingFileId: newFileId, // If cancelled, remove it
-      renameSource: 'explorer',
-    });
-  },
-
-  setRenamingFileId: (id, source) =>
-    set({ renamingFileId: id, renameSource: source ?? null }),
-
-  cancelRename: () => {
-    const { pendingFileId, openFiles, activeFileId, files, findFile } = get();
-
-    // If we are cancelling a pending file, remove it
-    if (pendingFileId) {
-      // Get the file path to delete from disk
-      const file = findFile(pendingFileId);
-      const filePath = file?.path;
-
-      // Delete from disk if it exists
-      if (filePath) {
-        invoke('delete_note', { path: filePath })
-          .then(() => console.log('Pending file deleted from disk:', filePath))
-          .catch((err) => console.error('Failed to delete pending file:', err));
-      }
-
-      const removeFile = (nodes: FileNode[]): FileNode[] => {
-        return nodes.filter((node) => {
-          if (node.id === pendingFileId) return false;
-          if (node.children) {
-            node.children = removeFile(node.children);
-          }
-          return true;
-        });
-      };
-
-      const newFiles = removeFile(files);
-      const newOpenFiles = openFiles.filter((id) => id !== pendingFileId);
-
-      // Determine next active file if we are closing the pending one
-      let nextActiveId = activeFileId;
-      if (activeFileId === pendingFileId) {
-        const lastFile =
-          newOpenFiles.length > 0
-            ? newOpenFiles[newOpenFiles.length - 1]
-            : null;
-        nextActiveId = lastFile || null;
-      }
-
-      set({
-        files: newFiles,
-        openFiles: newOpenFiles,
-        renamingFileId: null,
-        renameSource: null,
-        pendingFileId: null,
-        activeFileId: nextActiveId,
-      });
-    } else {
-      // Just stop renaming
-      set({ renamingFileId: null, renameSource: null });
-    }
-  },
-
-  renameFile: (id, newName) => {
-    const state = get();
-    const { workspacePath } = state;
-
-    // Handle new tab creation (deferred file creation)
-    if (id.startsWith('new-tab-')) {
-      if (!workspacePath) {
-        console.error('No workspace path set');
-        return;
-      }
-
-      const { files, openFiles } = state;
-
-      // Helper to check for name collisions
-      const checkNameExists = (name: string, nodes: FileNode[]): boolean => {
-        for (const node of nodes) {
-          if (node.name === name) return true;
-          if (node.children && checkNameExists(name, node.children))
-            return true;
-        }
-        return false;
-      };
-
-      // Ensure unique name
-      let finalName = newName;
-      if (!finalName.endsWith('.md')) finalName += '.md';
-      let nameCounter = 0;
-      const baseName = finalName.replace('.md', '');
-
-      while (checkNameExists(finalName, files)) {
-        nameCounter++;
-        finalName = `${baseName}-${nameCounter}.md`;
-      }
-
-      const filePath = `${workspacePath}/${finalName}`;
-      const newFileId = filePath;
-
-      const newFile: FileNode = {
-        id: newFileId,
-        name: finalName,
-        type: 'file',
-        path: filePath,
-        content: '',
-      };
-
-      // Create file on disk
-      invoke('create_note', { path: filePath })
-        .then(() => console.log('File created on disk:', filePath))
-        .catch((err) => console.error('Failed to create file:', err));
-
-      const newFiles = [...files, newFile];
-      const newOpenFiles = openFiles.map((fid) =>
-        fid === id ? newFileId : fid
-      );
-
-      set({
-        files: newFiles,
-        activeFileId: newFileId,
-        openFiles: newOpenFiles,
-        renamingFileId: null,
-        renameSource: null,
-        pendingFileId: null,
-      });
-      return;
-    }
-
-    // Find existing file to get its path
-    const file = state.findFile(id);
-    const oldPath = file?.path;
-
-    if (!oldPath) {
-      // Legacy in-memory rename (no path)
-      const updateName = (nodes: FileNode[]): FileNode[] => {
-        return nodes.map((node) => {
-          if (node.id === id) {
-            return { ...node, name: newName };
-          }
-          if (node.children) {
-            return { ...node, children: updateName(node.children) };
-          }
-          return node;
-        });
-      };
-
-      set((state) => ({
-        files: updateName(state.files),
-        renamingFileId: null,
-        renameSource: null,
-        pendingFileId: null,
-      }));
-      return;
-    }
-
-    // Calculate new path
-    const dir = oldPath.substring(0, oldPath.lastIndexOf('/'));
-    let finalName = newName;
-    if (!finalName.endsWith('.md')) finalName += '.md';
-    const newPath = `${dir}/${finalName}`;
-
-    // Rename on disk
-    invoke('rename_note', { oldPath, newPath })
-      .then(() => console.log('File renamed on disk:', newPath))
-      .catch((err) => console.error('Failed to rename file:', err));
-
-    // Update state with new path and id
-    const updateFileData = (nodes: FileNode[]): FileNode[] => {
-      return nodes.map((node) => {
-        if (node.id === id) {
-          return {
-            ...node,
-            id: newPath,
-            name: finalName,
-            path: newPath,
-          };
-        }
-        if (node.children) {
-          return { ...node, children: updateFileData(node.children) };
-        }
-        return node;
-      });
-    };
-
-    const { openFiles, activeFileId } = state;
-    const newOpenFiles = openFiles.map((fid) => (fid === id ? newPath : fid));
-    const newActiveId = activeFileId === id ? newPath : activeFileId;
-
-    set({
-      files: updateFileData(state.files),
-      openFiles: newOpenFiles,
-      activeFileId: newActiveId,
+      isExplorerCollapsed: false,
+      newTabCounter: 0,
       renamingFileId: null,
       renameSource: null,
       pendingFileId: null,
-    });
-  },
+      lastSidebarWidth: 20,
+      expandedFolderIds: [],
+      isAutoSave: true,
+      pinnedFiles: [],
 
-  toggleFolder: (folderId: string) => {
-    set((state) => {
-      const isExpanded = state.expandedFolderIds.includes(folderId);
-      return {
-        expandedFolderIds: isExpanded
-          ? state.expandedFolderIds.filter((id) => id !== folderId)
-          : [...state.expandedFolderIds, folderId],
-      };
-    });
-  },
+      isSearchOpen: false,
+      searchQuery: '',
+      searchResults: [],
 
-  expandFolder: (folderId: string) => {
-    set((state) => {
-      if (state.expandedFolderIds.includes(folderId)) return {};
-      return { expandedFolderIds: [...state.expandedFolderIds, folderId] };
-    });
-  },
+      // Workspace actions
+      setWorkspacePath: (path: string | null) => set({ workspacePath: path }),
 
-  collapseFolder: (folderId: string) => {
-    set((state) => ({
-      expandedFolderIds: state.expandedFolderIds.filter(
-        (id) => id !== folderId
-      ),
-    }));
-  },
+      setSearchOpen: (isOpen: boolean) => set({ isSearchOpen: isOpen }),
+      setSearchQuery: (query: string) => set({ searchQuery: query }),
+      setSearchResults: (results: SearchResult[]) =>
+        set({ searchResults: results }),
 
-  moveNode: (
-    sourceId: string,
-    targetId: string,
-    position: 'inside' | 'before' | 'after' | 'root'
-  ) => {
-    set((state) => {
-      const files = [...state.files];
+      setFiles: (files: FileNode[]) =>
+        set({
+          files,
+          activeFileId: null,
+          openFiles: [],
+          activeFileContent: '',
+          expandedFolderIds: [],
+        }),
 
-      // 1. Find and Remove Source
-      let detachedNode: FileNode | null = null;
+      resetWorkspace: () =>
+        set({
+          files: [],
+          workspacePath: null,
+          activeFileId: null,
+          openFiles: [],
+          activeFileContent: '',
+          expandedFolderIds: [],
+        }),
 
-      const removeNode = (nodes: FileNode[]): FileNode[] => {
-        const result: FileNode[] = [];
+      findFile: (id: string, nodes = get().files): FileNode | null => {
         for (const node of nodes) {
-          if (node.id === sourceId) {
-            detachedNode = node;
-            continue; // Remove it
-          }
+          if (node.id === id) return node;
           if (node.children) {
-            const newChildren = removeNode(node.children);
-            if (node.children !== newChildren) {
-              result.push({ ...node, children: newChildren });
-            } else {
-              result.push(node);
-            }
-          } else {
-            result.push(node);
+            const found = get().findFile(id, node.children);
+            if (found) return found;
           }
         }
-        return result;
-      };
+        return null;
+      },
 
-      const newFilesWithoutSource = removeNode(files);
+      getFileBreadcrumb: (fileId: string): FileNode[] => {
+        const breadcrumb: FileNode[] = [];
 
-      if (!detachedNode) {
-        return {};
-      }
-
-      // 2. Validate Target & Insert
-      if (targetId === 'root') {
-        return { files: [...newFilesWithoutSource, detachedNode!] };
-      }
-
-      let inserted = false;
-
-      // We need a pass to insert, then maybe a pass to fix names?
-      // Merging insertion and name fix is tricky with immutable recursive structure.
-      // Let's rely on `insertNode` for structural change.
-      // Warning: `insertNode` as written above for 'before/after' returns a flattened list for that level.
-      // But we need to update `newFilesWithoutSource` recursively.
-
-      // Re-write insertion to be cleaner
-      const insertRecursive = (list: FileNode[]): FileNode[] => {
-        const newList: FileNode[] = [];
-
-        for (const node of list) {
-          if (node.id === targetId) {
-            inserted = true;
-            // Prepare node to insert (detachedNode)
-            // We don't check name collision here optimally but let's assume UI handles it or we fix it later
-            // For now, inserted node gets raw name.
-
-            if (position === 'before') {
-              newList.push(detachedNode!);
-              newList.push(node);
-            } else if (position === 'after') {
-              newList.push(node);
-              newList.push(detachedNode!);
-            } else if (position === 'inside') {
-              const children = node.children || [];
-              const newChildren = [...children, detachedNode!];
-              newList.push({ ...node, children: newChildren });
+        const traverse = (nodes: FileNode[]): boolean => {
+          for (const node of nodes) {
+            breadcrumb.push(node);
+            if (node.id === fileId) {
+              return true;
             }
+            if (node.children && traverse(node.children)) {
+              return true;
+            }
+            breadcrumb.pop();
+          }
+          return false;
+        };
+
+        traverse(get().files);
+        return breadcrumb;
+      },
+
+      selectFile: (fileId: string) => {
+        // Handle blank tabs
+        if (fileId.startsWith('new-tab-')) {
+          set((state) => {
+            // If currently on welcome page, replace it
+            if (state.activeFileId === 'welcome') {
+              return {
+                activeFileId: fileId,
+                activeFileContent: '',
+                openFiles: [fileId], // Replace welcome entirely
+              };
+            }
+            return {
+              activeFileId: fileId,
+              activeFileContent: '',
+            };
+          });
+          return;
+        }
+
+        // Handle System Tabs
+        if (fileId.startsWith('cinder-')) {
+          set({ activeFileId: fileId, activeFileContent: '' });
+          return;
+        }
+
+        const file = get().findFile(fileId);
+        if (file && file.type === 'file') {
+          const { openFiles, activeFileId } = get();
+          const filePath = file.path;
+
+          // Helper to update state with content
+          const updateWithContent = (content: string) => {
+            const currentState = get();
+            const currentActiveId = currentState.activeFileId;
+
+            // If currently on a blank tab OR welcome tab, replace it
+            if (
+              currentActiveId &&
+              (currentActiveId.startsWith('new-tab-') ||
+                currentActiveId === 'welcome')
+            ) {
+              const newOpenFiles = currentState.openFiles.map((id) =>
+                id === currentActiveId ? fileId : id
+              );
+              set({
+                activeFileId: fileId,
+                activeFileContent: content,
+                openFiles: newOpenFiles,
+              });
+            } else {
+              // Otherwise, open in new tab if not already open
+              const needsToOpen = !currentState.openFiles.includes(fileId);
+              set({
+                activeFileId: fileId,
+                activeFileContent: content,
+                openFiles: needsToOpen
+                  ? [...currentState.openFiles, fileId]
+                  : currentState.openFiles,
+              });
+            }
+          };
+
+          // If file has a path, read from disk
+          if (filePath) {
+            // Set as active immediately with loading state
+            if (
+              activeFileId &&
+              (activeFileId.startsWith('new-tab-') ||
+                activeFileId === 'welcome')
+            ) {
+              const newOpenFiles = openFiles.map((id) =>
+                id === activeFileId ? fileId : id
+              );
+              set({
+                activeFileId: fileId,
+                openFiles: newOpenFiles,
+                activeFileContent: '',
+              });
+            } else {
+              const needsToOpen = !openFiles.includes(fileId);
+              set({
+                activeFileId: fileId,
+                openFiles: needsToOpen ? [...openFiles, fileId] : openFiles,
+                activeFileContent: '',
+              });
+            }
+
+            // Read content from disk
+            invoke<string>('read_note', { path: filePath })
+              .then((content) => {
+                // Only update if this file is still active
+                if (get().activeFileId === fileId) {
+                  set({ activeFileContent: content });
+                }
+              })
+              .catch((err) => {
+                console.error('Failed to read file:', err);
+                set({ activeFileContent: `Error loading file: ${err}` });
+              });
           } else {
-            if (node.children) {
-              const newChildren = insertRecursive(node.children);
-              if (newChildren !== node.children) {
-                newList.push({ ...node, children: newChildren });
-              } else {
-                newList.push(node);
+            // Fallback to in-memory content
+            updateWithContent(file.content || '');
+          }
+        }
+      },
+
+      openSystemTab: (tabId: string) => {
+        const { openFiles, activeFileId } = get();
+
+        // If already open, just select it
+        if (openFiles.includes(tabId)) {
+          set({ activeFileId: tabId, activeFileContent: '' });
+          return;
+        }
+
+        // If currently on welcome/blank, replace it
+        if (
+          activeFileId &&
+          (activeFileId === 'welcome' || activeFileId.startsWith('new-tab-'))
+        ) {
+          const newOpenFiles = openFiles.map((id) =>
+            id === activeFileId ? tabId : id
+          );
+          set({
+            activeFileId: tabId,
+            openFiles: newOpenFiles,
+            activeFileContent: '',
+          });
+        } else {
+          // Append
+          set({
+            activeFileId: tabId,
+            openFiles: [...openFiles, tabId],
+            activeFileContent: '',
+          });
+        }
+      },
+
+      toggleAutoSave: () => set((state) => ({ isAutoSave: !state.isAutoSave })),
+
+      togglePin: (fileId: string) =>
+        set((state) => {
+          const isPinned = state.pinnedFiles.includes(fileId);
+          return {
+            pinnedFiles: isPinned
+              ? state.pinnedFiles.filter((id) => id !== fileId)
+              : [...state.pinnedFiles, fileId],
+          };
+        }),
+
+      openFileInNewTab: (fileId: string) => {
+        const file = get().findFile(fileId);
+        if (file && file.type === 'file') {
+          const { openFiles, activeFileId } = get();
+          const filePath = file.path;
+
+          // Set as active immediately
+          if (
+            activeFileId &&
+            (activeFileId.startsWith('new-tab-') || activeFileId === 'welcome')
+          ) {
+            const newOpenFiles = openFiles.map((id) =>
+              id === activeFileId ? fileId : id
+            );
+            set({
+              activeFileId: fileId,
+              openFiles: newOpenFiles,
+              activeFileContent: '',
+            });
+          } else {
+            const needsToOpen = !openFiles.includes(fileId);
+            set({
+              activeFileId: fileId,
+              openFiles: needsToOpen ? [...openFiles, fileId] : openFiles,
+              activeFileContent: '',
+            });
+          }
+
+          // If file has a path, read from disk
+          if (filePath) {
+            invoke<string>('read_note', { path: filePath })
+              .then((content) => {
+                if (get().activeFileId === fileId) {
+                  set({ activeFileContent: content });
+                }
+              })
+              .catch((err) => {
+                console.error('Failed to read file:', err);
+                set({ activeFileContent: `Error loading file: ${err}` });
+              });
+          } else {
+            // Fallback to in-memory content
+            set({ activeFileContent: file.content || '' });
+          }
+        }
+      },
+
+      closeFile: (fileId: string) => {
+        const { openFiles, activeFileId } = get();
+        const newOpenFiles = openFiles.filter((id) => id !== fileId);
+
+        if (activeFileId === fileId) {
+          const nextActive =
+            newOpenFiles.length > 0
+              ? newOpenFiles[newOpenFiles.length - 1]
+              : null;
+          if (nextActive) {
+            get().selectFile(nextActive);
+          } else {
+            set({ activeFileId: null, activeFileContent: '' });
+            // If we closed the last tab, we might want to show empty state or Welcome?
+            // For now, empty state is fine.
+          }
+        }
+
+        set({ openFiles: newOpenFiles });
+      },
+
+      updateFileContent: (fileId: string, content: string) => {
+        const state = get();
+        const { workspacePath } = state;
+
+        // Handle deferred creation for new tabs
+        if (fileId.startsWith('new-tab-')) {
+          if (!workspacePath) {
+            console.error('No workspace path set');
+            return;
+          }
+
+          const { files, openFiles } = state;
+
+          // Find a unique name
+          let nameCounter = 0;
+          const baseName = 'untitled';
+          const extension = '.md';
+          let newName = `${baseName}${extension}`;
+
+          const checkNameExists = (
+            name: string,
+            nodes: FileNode[]
+          ): boolean => {
+            for (const node of nodes) {
+              if (node.name === name) return true;
+              if (node.children && checkNameExists(name, node.children))
+                return true;
+            }
+            return false;
+          };
+
+          while (checkNameExists(newName, files)) {
+            nameCounter++;
+            newName = `${baseName}-${nameCounter}${extension}`;
+          }
+
+          const filePath = `${workspacePath}/${newName}`;
+          const newFileId = filePath;
+
+          const newFile: FileNode = {
+            id: newFileId,
+            name: newName,
+            type: 'file',
+            path: filePath,
+            content: content,
+          };
+
+          // Create file on disk with content
+          invoke('write_note', { path: filePath, content })
+            .then(() => console.log('File created on disk:', filePath))
+            .catch((err) => console.error('Failed to create file:', err));
+
+          const newFiles = [...files, newFile];
+          const newOpenFiles = openFiles.map((id) =>
+            id === fileId ? newFileId : id
+          );
+
+          set({
+            files: newFiles,
+            activeFileId: newFileId,
+            openFiles: newOpenFiles,
+            activeFileContent: content,
+          });
+          return;
+        }
+
+        // Find the file to get its path
+        const file = state.findFile(fileId);
+        const filePath = file?.path;
+
+        // Write to disk if we have a path
+        if (filePath) {
+          invoke('write_note', { path: filePath, content })
+            .then(() => console.log('File saved:', filePath))
+            .catch((err) => console.error('Failed to save file:', err));
+        }
+
+        // Normal update - Persist to store AND active state
+        set((state) => {
+          const updateContentRecursive = (nodes: FileNode[]): FileNode[] => {
+            return nodes.map((node) => {
+              if (node.id === fileId) {
+                return { ...node, content };
               }
-            } else {
-              newList.push(node);
-            }
-          }
-        }
-        return newList;
-      };
+              if (node.children) {
+                return {
+                  ...node,
+                  children: updateContentRecursive(node.children),
+                };
+              }
+              return node;
+            });
+          };
 
-      const finalFiles = insertRecursive(newFilesWithoutSource);
-
-      if (!inserted) {
-        return {}; // Return nothing to keep original state
-      }
-
-      return { files: finalFiles };
-    });
-  },
-
-  toggleAutoSave: () => {
-    set((state) => ({ isAutoSave: !state.isAutoSave }));
-  },
-
-  // --- Context Menu Actions ---
-
-  deleteFile: (fileId: string) => {
-    const state = get();
-    const file = state.findFile(fileId);
-    const filePath = file?.path;
-
-    // Delete from disk
-    if (filePath) {
-      invoke('delete_note', { path: filePath })
-        .then(() => console.log('File deleted from disk:', filePath))
-        .catch((err) => console.error('Failed to delete file:', err));
-    }
-
-    // Remove from file tree
-    const removeFromTree = (nodes: FileNode[]): FileNode[] => {
-      return nodes
-        .filter((node) => {
-          if (node.id === fileId) return false;
-          if (node.children) {
-            node = { ...node, children: removeFromTree(node.children) };
-          }
-          return true;
-        })
-        .map((node) => {
-          if (node.children) {
-            return { ...node, children: removeFromTree(node.children) };
-          }
-          return node;
+          return {
+            activeFileContent:
+              state.activeFileId === fileId ? content : state.activeFileContent,
+            files: updateContentRecursive(state.files),
+          };
         });
-    };
+      },
 
-    const newFiles = removeFromTree(state.files);
-    const newOpenFiles = state.openFiles.filter((id) => id !== fileId);
+      toggleExplorerCollapsed: () => {
+        set((state) => {
+          const willExpand = state.isExplorerCollapsed;
+          let newWidth = state.sidebarWidth;
 
-    // Determine next active file
-    let nextActiveId = state.activeFileId;
-    if (state.activeFileId === fileId) {
-      nextActiveId =
-        newOpenFiles.length > 0 ? newOpenFiles[newOpenFiles.length - 1] : null;
-    }
-
-    set({
-      files: newFiles,
-      openFiles: newOpenFiles,
-      activeFileId: nextActiveId,
-      activeFileContent:
-        nextActiveId === state.activeFileId ? state.activeFileContent : '',
-    });
-
-    // If there's a next active file, select it to load content
-    if (nextActiveId && nextActiveId !== state.activeFileId) {
-      get().selectFile(nextActiveId);
-    }
-  },
-
-  deleteFolder: (folderId: string) => {
-    const state = get();
-    const folder = state.findFile(folderId);
-    const folderPath = folder?.path;
-
-    // Delete from disk
-    if (folderPath) {
-      invoke('delete_folder', { path: folderPath })
-        .then(() => console.log('Folder deleted from disk:', folderPath))
-        .catch((err) => console.error('Failed to delete folder:', err));
-    }
-
-    // Collect all file IDs inside the folder (to close their tabs)
-    const collectFileIds = (node: FileNode): string[] => {
-      const ids: string[] = [node.id];
-      if (node.children) {
-        for (const child of node.children) {
-          ids.push(...collectFileIds(child));
-        }
-      }
-      return ids;
-    };
-
-    const idsToRemove = folder ? collectFileIds(folder) : [folderId];
-
-    // Remove from file tree
-    const removeFromTree = (nodes: FileNode[]): FileNode[] => {
-      return nodes
-        .filter((node) => node.id !== folderId)
-        .map((node) => {
-          if (node.children) {
-            return { ...node, children: removeFromTree(node.children) };
+          // If expanding and current width is too small (e.g. it was dragged to collapse boundary)
+          // Restore to last good size
+          if (willExpand && newWidth < 20) {
+            newWidth = state.lastSidebarWidth || 20;
           }
-          return node;
+
+          return {
+            isExplorerCollapsed: !state.isExplorerCollapsed,
+            sidebarWidth: newWidth,
+          };
         });
-    };
+      },
 
-    const newFiles = removeFromTree(state.files);
-    const newOpenFiles = state.openFiles.filter(
-      (id) => !idsToRemove.includes(id)
-    );
-    const newExpandedFolderIds = state.expandedFolderIds.filter(
-      (id) => !idsToRemove.includes(id)
-    );
+      setExplorerCollapsed: (isCollapsed: boolean) => {
+        set((state) => {
+          // If manual set to expanded, also check width
+          if (!isCollapsed && state.sidebarWidth < 20) {
+            return {
+              isExplorerCollapsed: isCollapsed,
+              sidebarWidth: state.lastSidebarWidth || 20,
+            };
+          }
+          return { isExplorerCollapsed: isCollapsed };
+        });
+      },
 
-    let nextActiveId = state.activeFileId;
-    if (state.activeFileId && idsToRemove.includes(state.activeFileId)) {
-      nextActiveId =
-        newOpenFiles.length > 0 ? newOpenFiles[newOpenFiles.length - 1] : null;
-    }
+      sidebarWidth: 20,
+      setSidebarWidth: (width: number) => {
+        set((state) => ({
+          sidebarWidth: width,
+          lastSidebarWidth: width >= 20 ? width : state.lastSidebarWidth,
+        }));
+      },
 
-    set({
-      files: newFiles,
-      openFiles: newOpenFiles,
-      expandedFolderIds: newExpandedFolderIds,
-      activeFileId: nextActiveId,
-      activeFileContent: '',
-    });
+      createNewTab: () => {
+        set((state) => {
+          const newCounter = state.newTabCounter + 1;
+          const newTabId = `new-tab-${newCounter}`;
 
-    if (nextActiveId && nextActiveId !== state.activeFileId) {
-      get().selectFile(nextActiveId);
-    }
-  },
+          // If currently on welcome, replace it
+          if (state.activeFileId === 'welcome') {
+            return {
+              newTabCounter: newCounter,
+              activeFileId: newTabId,
+              openFiles: [newTabId],
+              activeFileContent: '',
+              renamingFileId: null, // Don't rename yet
+              renameSource: null,
+            };
+          }
 
-  duplicateFile: (fileId: string) => {
-    const state = get();
-    const file = state.findFile(fileId);
-    if (!file || !file.path) return;
+          return {
+            newTabCounter: newCounter,
+            activeFileId: newTabId,
+            openFiles: [...state.openFiles, newTabId],
+            activeFileContent: '',
+            renamingFileId: newTabId,
+            renameSource: 'editor',
+          };
+        });
+      },
 
-    const dir = file.path.substring(0, file.path.lastIndexOf('/'));
-    const baseName = file.name.replace(/\.md$/, '');
-    const extension = '.md';
+      createFile: () => {
+        // Creates file in tree immediately with rename mode active
+        // Also creates it on disk immediately
+        const state = get();
+        const { files, openFiles, workspacePath } = state;
 
-    // Find unique name
-    let copyName = `${baseName} (copy)${extension}`;
-    let counter = 1;
+        if (!workspacePath) {
+          console.error('No workspace path set');
+          return;
+        }
 
-    const checkNameExists = (name: string, nodes: FileNode[]): boolean => {
-      for (const node of nodes) {
-        if (node.name === name) return true;
-        if (node.children && checkNameExists(name, node.children)) return true;
-      }
-      return false;
-    };
+        // Generate unique name
+        let nameCounter = 0;
+        const baseName = 'New File';
+        const extension = '.md';
+        let newName = `${baseName}${extension}`;
 
-    while (checkNameExists(copyName, state.files)) {
-      counter++;
-      copyName = `${baseName} (copy ${counter})${extension}`;
-    }
+        const checkNameExists = (name: string, nodes: FileNode[]): boolean => {
+          for (const node of nodes) {
+            if (node.name === name) return true;
+          }
+          return false;
+        };
 
-    const copyPath = `${dir}/${copyName}`;
-    const copyId = copyPath;
+        while (checkNameExists(newName, files)) {
+          nameCounter++;
+          newName = `${baseName} ${nameCounter}${extension}`;
+        }
 
-    // Read original content then write the copy
-    invoke<string>('read_note', { path: file.path })
-      .then((content) => {
-        return invoke('write_note', { path: copyPath, content });
-      })
-      .then(() => {
+        const filePath = `${workspacePath}/${newName}`;
+        const newFileId = filePath; // Use path as ID for consistency
+
         const newFile: FileNode = {
-          id: copyId,
-          name: copyName,
+          id: newFileId,
+          name: newName,
           type: 'file',
-          path: copyPath,
+          path: filePath,
           content: '',
         };
 
-        // Insert copy next to the original in the tree
-        const insertCopy = (nodes: FileNode[]): FileNode[] => {
-          const result: FileNode[] = [];
-          for (const node of nodes) {
-            result.push(node);
-            if (node.id === fileId) {
-              result.push(newFile);
+        // Create file on disk
+        invoke('create_note', { path: filePath })
+          .then(() => {
+            console.log('File created on disk:', filePath);
+          })
+          .catch((err) => {
+            console.error('Failed to create file on disk:', err);
+          });
+
+        // Add to file tree at root level
+        const newFiles = [...files, newFile];
+        const newOpenFiles = [...openFiles, newFileId];
+
+        set({
+          files: newFiles,
+          activeFileId: newFileId,
+          openFiles: newOpenFiles,
+          activeFileContent: '',
+          renamingFileId: newFileId,
+          pendingFileId: newFileId, // If cancelled, remove it
+          renameSource: 'explorer',
+        });
+      },
+
+      setRenamingFileId: (id, source) =>
+        set({ renamingFileId: id, renameSource: source ?? null }),
+
+      cancelRename: () => {
+        const { pendingFileId, openFiles, activeFileId, files, findFile } =
+          get();
+
+        // If we are cancelling a pending file, remove it
+        if (pendingFileId) {
+          // Get the file path to delete from disk
+          const file = findFile(pendingFileId);
+          const filePath = file?.path;
+
+          // Delete from disk if it exists
+          if (filePath) {
+            invoke('delete_note', { path: filePath })
+              .then(() =>
+                console.log('Pending file deleted from disk:', filePath)
+              )
+              .catch((err) =>
+                console.error('Failed to delete pending file:', err)
+              );
+          }
+
+          const removeFile = (nodes: FileNode[]): FileNode[] => {
+            return nodes.filter((node) => {
+              if (node.id === pendingFileId) return false;
+              if (node.children) {
+                node.children = removeFile(node.children);
+              }
+              return true;
+            });
+          };
+
+          const newFiles = removeFile(files);
+          const newOpenFiles = openFiles.filter((id) => id !== pendingFileId);
+
+          // Determine next active file if we are closing the pending one
+          let nextActiveId = activeFileId;
+          if (activeFileId === pendingFileId) {
+            const lastFile =
+              newOpenFiles.length > 0
+                ? newOpenFiles[newOpenFiles.length - 1]
+                : null;
+            nextActiveId = lastFile || null;
+          }
+
+          set({
+            files: newFiles,
+            openFiles: newOpenFiles,
+            renamingFileId: null,
+            renameSource: null,
+            pendingFileId: null,
+            activeFileId: nextActiveId,
+          });
+        } else {
+          // Just stop renaming
+          set({ renamingFileId: null, renameSource: null });
+        }
+      },
+
+      renameFile: (id, newName) => {
+        const state = get();
+        const { workspacePath } = state;
+
+        // Handle new tab creation (deferred file creation)
+        if (id.startsWith('new-tab-')) {
+          if (!workspacePath) {
+            console.error('No workspace path set');
+            return;
+          }
+
+          const { files, openFiles } = state;
+
+          // Helper to check for name collisions
+          const checkNameExists = (
+            name: string,
+            nodes: FileNode[]
+          ): boolean => {
+            for (const node of nodes) {
+              if (node.name === name) return true;
+              if (node.children && checkNameExists(name, node.children))
+                return true;
+            }
+            return false;
+          };
+
+          // Ensure unique name
+          let finalName = newName;
+          if (!finalName.endsWith('.md')) finalName += '.md';
+          let nameCounter = 0;
+          const baseName = finalName.replace('.md', '');
+
+          while (checkNameExists(finalName, files)) {
+            nameCounter++;
+            finalName = `${baseName}-${nameCounter}.md`;
+          }
+
+          const filePath = `${workspacePath}/${finalName}`;
+          const newFileId = filePath;
+
+          const newFile: FileNode = {
+            id: newFileId,
+            name: finalName,
+            type: 'file',
+            path: filePath,
+            content: '',
+          };
+
+          // Create file on disk
+          invoke('create_note', { path: filePath })
+            .then(() => console.log('File created on disk:', filePath))
+            .catch((err) => console.error('Failed to create file:', err));
+
+          const newFiles = [...files, newFile];
+          const newOpenFiles = openFiles.map((fid) =>
+            fid === id ? newFileId : fid
+          );
+
+          set({
+            files: newFiles,
+            activeFileId: newFileId,
+            openFiles: newOpenFiles,
+            renamingFileId: null,
+            renameSource: null,
+            pendingFileId: null,
+          });
+          return;
+        }
+
+        // Find existing file to get its path
+        const file = state.findFile(id);
+        const oldPath = file?.path;
+
+        if (!oldPath) {
+          // Legacy in-memory rename (no path)
+          const updateName = (nodes: FileNode[]): FileNode[] => {
+            return nodes.map((node) => {
+              if (node.id === id) {
+                return { ...node, name: newName };
+              }
+              if (node.children) {
+                return { ...node, children: updateName(node.children) };
+              }
+              return node;
+            });
+          };
+
+          set((state) => ({
+            files: updateName(state.files),
+            renamingFileId: null,
+            renameSource: null,
+            pendingFileId: null,
+          }));
+          return;
+        }
+
+        // Calculate new path
+        const dir = oldPath.substring(0, oldPath.lastIndexOf('/'));
+        let finalName = newName;
+        if (!finalName.endsWith('.md')) finalName += '.md';
+        const newPath = `${dir}/${finalName}`;
+
+        // Rename on disk
+        invoke('rename_note', { oldPath, newPath })
+          .then(() => console.log('File renamed on disk:', newPath))
+          .catch((err) => console.error('Failed to rename file:', err));
+
+        // Update state with new path and id
+        const updateFileData = (nodes: FileNode[]): FileNode[] => {
+          return nodes.map((node) => {
+            if (node.id === id) {
+              return {
+                ...node,
+                id: newPath,
+                name: finalName,
+                path: newPath,
+              };
             }
             if (node.children) {
-              const updatedNode = {
-                ...result[result.length - 1],
-                children: insertCopy(node.children),
-              };
-              result[result.length - 1] = updatedNode;
+              return { ...node, children: updateFileData(node.children) };
             }
-          }
-          return result;
+            return node;
+          });
         };
 
-        set((state) => ({
-          files: insertCopy(state.files),
-        }));
-      })
-      .catch((err) => console.error('Failed to duplicate file:', err));
-  },
+        const { openFiles, activeFileId } = state;
+        const newOpenFiles = openFiles.map((fid) =>
+          fid === id ? newPath : fid
+        );
+        const newActiveId = activeFileId === id ? newPath : activeFileId;
 
-  createFileInFolder: (folderId: string) => {
-    const state = get();
-    const { files, openFiles, workspacePath } = state;
-    const folder = state.findFile(folderId);
-
-    if (!workspacePath || !folder || !folder.path) {
-      console.error('No workspace or folder path');
-      return;
-    }
-
-    // Generate unique name within the folder
-    let nameCounter = 0;
-    const baseName = 'New File';
-    const extension = '.md';
-    let newName = `${baseName}${extension}`;
-
-    const siblings = folder.children || [];
-    const checkNameExists = (name: string): boolean => {
-      return siblings.some((node) => node.name === name);
-    };
-
-    while (checkNameExists(newName)) {
-      nameCounter++;
-      newName = `${baseName} ${nameCounter}${extension}`;
-    }
-
-    const filePath = `${folder.path}/${newName}`;
-    const newFileId = filePath;
-
-    const newFile: FileNode = {
-      id: newFileId,
-      name: newName,
-      type: 'file',
-      path: filePath,
-      content: '',
-    };
-
-    // Create on disk
-    invoke('create_note', { path: filePath })
-      .then(() => console.log('File created inside folder:', filePath))
-      .catch((err) => console.error('Failed to create file in folder:', err));
-
-    // Add to the folder's children in the tree
-    const addToFolder = (nodes: FileNode[]): FileNode[] => {
-      return nodes.map((node) => {
-        if (node.id === folderId) {
-          return { ...node, children: [...(node.children || []), newFile] };
-        }
-        if (node.children) {
-          return { ...node, children: addToFolder(node.children) };
-        }
-        return node;
-      });
-    };
-
-    // Expand the folder so the new file is visible
-    const newExpandedFolderIds = state.expandedFolderIds.includes(folderId)
-      ? state.expandedFolderIds
-      : [...state.expandedFolderIds, folderId];
-
-    set({
-      files: addToFolder(files),
-      activeFileId: newFileId,
-      openFiles: [...openFiles, newFileId],
-      activeFileContent: '',
-      renamingFileId: newFileId,
-      pendingFileId: newFileId,
-      renameSource: 'explorer',
-      expandedFolderIds: newExpandedFolderIds,
-    });
-  },
-
-  createFolder: (parentFolderId?: string | null) => {
-    const state = get();
-    const { files, workspacePath } = state;
-
-    if (!workspacePath) {
-      console.error('No workspace path set');
-      return;
-    }
-
-    let parentPath = workspacePath;
-    let siblings = files;
-
-    if (parentFolderId) {
-      const parent = state.findFile(parentFolderId);
-      if (parent && parent.path) {
-        parentPath = parent.path;
-        siblings = parent.children || [];
-      }
-    }
-
-    // Generate unique folder name
-    let nameCounter = 0;
-    const baseName = 'New Folder';
-    let newName = baseName;
-
-    const checkNameExists = (name: string): boolean => {
-      return siblings.some((node) => node.name === name);
-    };
-
-    while (checkNameExists(newName)) {
-      nameCounter++;
-      newName = `${baseName} ${nameCounter}`;
-    }
-
-    const folderPath = `${parentPath}/${newName}`;
-    const folderId = folderPath;
-
-    const newFolder: FileNode = {
-      id: folderId,
-      name: newName,
-      type: 'folder',
-      path: folderPath,
-      children: [],
-    };
-
-    // Create on disk
-    invoke('create_folder', { path: folderPath })
-      .then(() => console.log('Folder created on disk:', folderPath))
-      .catch((err) => console.error('Failed to create folder:', err));
-
-    if (parentFolderId) {
-      // Add inside parent
-      const addToParent = (nodes: FileNode[]): FileNode[] => {
-        return nodes.map((node) => {
-          if (node.id === parentFolderId) {
-            return { ...node, children: [...(node.children || []), newFolder] };
-          }
-          if (node.children) {
-            return { ...node, children: addToParent(node.children) };
-          }
-          return node;
+        set({
+          files: updateFileData(state.files),
+          openFiles: newOpenFiles,
+          activeFileId: newActiveId,
+          renamingFileId: null,
+          renameSource: null,
+          pendingFileId: null,
         });
-      };
+      },
 
-      const newExpandedFolderIds = state.expandedFolderIds.includes(
-        parentFolderId
-      )
-        ? state.expandedFolderIds
-        : [...state.expandedFolderIds, parentFolderId];
+      toggleFolder: (folderId: string) => {
+        set((state) => {
+          const isExpanded = state.expandedFolderIds.includes(folderId);
+          return {
+            expandedFolderIds: isExpanded
+              ? state.expandedFolderIds.filter((id) => id !== folderId)
+              : [...state.expandedFolderIds, folderId],
+          };
+        });
+      },
 
-      set({
-        files: addToParent(files),
-        expandedFolderIds: [...newExpandedFolderIds, folderId],
-      });
-    } else {
-      // Add at root
-      set({
-        files: [...files, newFolder],
-        expandedFolderIds: [...state.expandedFolderIds, folderId],
-      });
+      expandFolder: (folderId: string) => {
+        set((state) => {
+          if (state.expandedFolderIds.includes(folderId)) return {};
+          return { expandedFolderIds: [...state.expandedFolderIds, folderId] };
+        });
+      },
+
+      collapseFolder: (folderId: string) => {
+        set((state) => ({
+          expandedFolderIds: state.expandedFolderIds.filter(
+            (id) => id !== folderId
+          ),
+        }));
+      },
+
+      moveNode: (
+        sourceId: string,
+        targetId: string,
+        position: 'inside' | 'before' | 'after' | 'root'
+      ) => {
+        set((state) => {
+          const files = [...state.files];
+
+          // 1. Find and Remove Source
+          let detachedNode: FileNode | null = null;
+
+          const removeNode = (nodes: FileNode[]): FileNode[] => {
+            const result: FileNode[] = [];
+            for (const node of nodes) {
+              if (node.id === sourceId) {
+                detachedNode = node;
+                continue; // Remove it
+              }
+              if (node.children) {
+                const newChildren = removeNode(node.children);
+                if (node.children !== newChildren) {
+                  result.push({ ...node, children: newChildren });
+                } else {
+                  result.push(node);
+                }
+              } else {
+                result.push(node);
+              }
+            }
+            return result;
+          };
+
+          const newFilesWithoutSource = removeNode(files);
+
+          if (!detachedNode) {
+            return {};
+          }
+
+          // 2. Validate Target & Insert
+          if (targetId === 'root') {
+            return { files: [...newFilesWithoutSource, detachedNode!] };
+          }
+
+          let inserted = false;
+
+          // We need a pass to insert, then maybe a pass to fix names?
+          // Merging insertion and name fix is tricky with immutable recursive structure.
+          // Let's rely on `insertNode` for structural change.
+          // Warning: `insertNode` as written above for 'before/after' returns a flattened list for that level.
+          // But we need to update `newFilesWithoutSource` recursively.
+
+          // Re-write insertion to be cleaner
+          const insertRecursive = (list: FileNode[]): FileNode[] => {
+            const newList: FileNode[] = [];
+
+            for (const node of list) {
+              if (node.id === targetId) {
+                inserted = true;
+                // Prepare node to insert (detachedNode)
+                // We don't check name collision here optimally but let's assume UI handles it or we fix it later
+                // For now, inserted node gets raw name.
+
+                if (position === 'before') {
+                  newList.push(detachedNode!);
+                  newList.push(node);
+                } else if (position === 'after') {
+                  newList.push(node);
+                  newList.push(detachedNode!);
+                } else if (position === 'inside') {
+                  const children = node.children || [];
+                  const newChildren = [...children, detachedNode!];
+                  newList.push({ ...node, children: newChildren });
+                }
+              } else {
+                if (node.children) {
+                  const newChildren = insertRecursive(node.children);
+                  if (newChildren !== node.children) {
+                    newList.push({ ...node, children: newChildren });
+                  } else {
+                    newList.push(node);
+                  }
+                } else {
+                  newList.push(node);
+                }
+              }
+            }
+            return newList;
+          };
+
+          const finalFiles = insertRecursive(newFilesWithoutSource);
+
+          if (!inserted) {
+            return {}; // Return nothing to keep original state
+          }
+
+          return { files: finalFiles };
+        });
+      },
+
+      // --- Context Menu Actions ---
+
+      deleteFile: (fileId: string) => {
+        const state = get();
+        const file = state.findFile(fileId);
+        const filePath = file?.path;
+
+        // Delete from disk
+        if (filePath) {
+          invoke('delete_note', { path: filePath })
+            .then(() => console.log('File deleted from disk:', filePath))
+            .catch((err) => console.error('Failed to delete file:', err));
+        }
+
+        // Remove from file tree
+        const removeFromTree = (nodes: FileNode[]): FileNode[] => {
+          return nodes
+            .filter((node) => {
+              if (node.id === fileId) return false;
+              if (node.children) {
+                node = { ...node, children: removeFromTree(node.children) };
+              }
+              return true;
+            })
+            .map((node) => {
+              if (node.children) {
+                return { ...node, children: removeFromTree(node.children) };
+              }
+              return node;
+            });
+        };
+
+        const newFiles = removeFromTree(state.files);
+        const newOpenFiles = state.openFiles.filter((id) => id !== fileId);
+
+        // Determine next active file
+        let nextActiveId = state.activeFileId;
+        if (state.activeFileId === fileId) {
+          nextActiveId =
+            newOpenFiles.length > 0
+              ? newOpenFiles[newOpenFiles.length - 1]
+              : null;
+        }
+
+        set({
+          files: newFiles,
+          openFiles: newOpenFiles,
+          activeFileId: nextActiveId,
+          activeFileContent:
+            nextActiveId === state.activeFileId ? state.activeFileContent : '',
+        });
+
+        // If there's a next active file, select it to load content
+        if (nextActiveId && nextActiveId !== state.activeFileId) {
+          get().selectFile(nextActiveId);
+        }
+      },
+
+      deleteFolder: (folderId: string) => {
+        const state = get();
+        const folder = state.findFile(folderId);
+        const folderPath = folder?.path;
+
+        // Delete from disk
+        if (folderPath) {
+          invoke('delete_folder', { path: folderPath })
+            .then(() => console.log('Folder deleted from disk:', folderPath))
+            .catch((err) => console.error('Failed to delete folder:', err));
+        }
+
+        // Collect all file IDs inside the folder (to close their tabs)
+        const collectFileIds = (node: FileNode): string[] => {
+          const ids: string[] = [node.id];
+          if (node.children) {
+            for (const child of node.children) {
+              ids.push(...collectFileIds(child));
+            }
+          }
+          return ids;
+        };
+
+        const idsToRemove = folder ? collectFileIds(folder) : [folderId];
+
+        // Remove from file tree
+        const removeFromTree = (nodes: FileNode[]): FileNode[] => {
+          return nodes
+            .filter((node) => node.id !== folderId)
+            .map((node) => {
+              if (node.children) {
+                return { ...node, children: removeFromTree(node.children) };
+              }
+              return node;
+            });
+        };
+
+        const newFiles = removeFromTree(state.files);
+        const newOpenFiles = state.openFiles.filter(
+          (id) => !idsToRemove.includes(id)
+        );
+        const newExpandedFolderIds = state.expandedFolderIds.filter(
+          (id) => !idsToRemove.includes(id)
+        );
+
+        let nextActiveId = state.activeFileId;
+        if (state.activeFileId && idsToRemove.includes(state.activeFileId)) {
+          nextActiveId =
+            newOpenFiles.length > 0
+              ? newOpenFiles[newOpenFiles.length - 1]
+              : null;
+        }
+
+        set({
+          files: newFiles,
+          openFiles: newOpenFiles,
+          expandedFolderIds: newExpandedFolderIds,
+          activeFileId: nextActiveId,
+          activeFileContent: '',
+        });
+
+        if (nextActiveId && nextActiveId !== state.activeFileId) {
+          get().selectFile(nextActiveId);
+        }
+      },
+
+      duplicateFile: (fileId: string) => {
+        const state = get();
+        const file = state.findFile(fileId);
+        if (!file || !file.path) return;
+
+        const dir = file.path.substring(0, file.path.lastIndexOf('/'));
+        const baseName = file.name.replace(/\.md$/, '');
+        const extension = '.md';
+
+        // Find unique name
+        let copyName = `${baseName} (copy)${extension}`;
+        let counter = 1;
+
+        const checkNameExists = (name: string, nodes: FileNode[]): boolean => {
+          for (const node of nodes) {
+            if (node.name === name) return true;
+            if (node.children && checkNameExists(name, node.children))
+              return true;
+          }
+          return false;
+        };
+
+        while (checkNameExists(copyName, state.files)) {
+          counter++;
+          copyName = `${baseName} (copy ${counter})${extension}`;
+        }
+
+        const copyPath = `${dir}/${copyName}`;
+        const copyId = copyPath;
+
+        // Read original content then write the copy
+        invoke<string>('read_note', { path: file.path })
+          .then((content) => {
+            return invoke('write_note', { path: copyPath, content });
+          })
+          .then(() => {
+            const newFile: FileNode = {
+              id: copyId,
+              name: copyName,
+              type: 'file',
+              path: copyPath,
+              content: '',
+            };
+
+            // Insert copy next to the original in the tree
+            const insertCopy = (nodes: FileNode[]): FileNode[] => {
+              const result: FileNode[] = [];
+              for (const node of nodes) {
+                result.push(node);
+                if (node.id === fileId) {
+                  result.push(newFile);
+                }
+                if (node.children) {
+                  const updatedNode = {
+                    ...result[result.length - 1],
+                    children: insertCopy(node.children),
+                  };
+                  result[result.length - 1] = updatedNode;
+                }
+              }
+              return result;
+            };
+
+            set((state) => ({
+              files: insertCopy(state.files),
+            }));
+          })
+          .catch((err) => console.error('Failed to duplicate file:', err));
+      },
+
+      createFileInFolder: (folderId: string) => {
+        const state = get();
+        const { files, openFiles, workspacePath } = state;
+        const folder = state.findFile(folderId);
+
+        if (!workspacePath || !folder || !folder.path) {
+          console.error('No workspace or folder path');
+          return;
+        }
+
+        // Generate unique name within the folder
+        let nameCounter = 0;
+        const baseName = 'New File';
+        const extension = '.md';
+        let newName = `${baseName}${extension}`;
+
+        const siblings = folder.children || [];
+        const checkNameExists = (name: string): boolean => {
+          return siblings.some((node) => node.name === name);
+        };
+
+        while (checkNameExists(newName)) {
+          nameCounter++;
+          newName = `${baseName} ${nameCounter}${extension}`;
+        }
+
+        const filePath = `${folder.path}/${newName}`;
+        const newFileId = filePath;
+
+        const newFile: FileNode = {
+          id: newFileId,
+          name: newName,
+          type: 'file',
+          path: filePath,
+          content: '',
+        };
+
+        // Create on disk
+        invoke('create_note', { path: filePath })
+          .then(() => console.log('File created inside folder:', filePath))
+          .catch((err) =>
+            console.error('Failed to create file in folder:', err)
+          );
+
+        // Add to the folder's children in the tree
+        const addToFolder = (nodes: FileNode[]): FileNode[] => {
+          return nodes.map((node) => {
+            if (node.id === folderId) {
+              return { ...node, children: [...(node.children || []), newFile] };
+            }
+            if (node.children) {
+              return { ...node, children: addToFolder(node.children) };
+            }
+            return node;
+          });
+        };
+
+        // Expand the folder so the new file is visible
+        const newExpandedFolderIds = state.expandedFolderIds.includes(folderId)
+          ? state.expandedFolderIds
+          : [...state.expandedFolderIds, folderId];
+
+        set({
+          files: addToFolder(files),
+          activeFileId: newFileId,
+          openFiles: [...openFiles, newFileId],
+          activeFileContent: '',
+          renamingFileId: newFileId,
+          pendingFileId: newFileId,
+          renameSource: 'explorer',
+          expandedFolderIds: newExpandedFolderIds,
+        });
+      },
+
+      createFolder: (parentFolderId?: string | null) => {
+        const state = get();
+        const { files, workspacePath } = state;
+
+        if (!workspacePath) {
+          console.error('No workspace path set');
+          return;
+        }
+
+        let parentPath = workspacePath;
+        let siblings = files;
+
+        if (parentFolderId) {
+          const parent = state.findFile(parentFolderId);
+          if (parent && parent.path) {
+            parentPath = parent.path;
+            siblings = parent.children || [];
+          }
+        }
+
+        // Generate unique folder name
+        let nameCounter = 0;
+        const baseName = 'New Folder';
+        let newName = baseName;
+
+        const checkNameExists = (name: string): boolean => {
+          return siblings.some((node) => node.name === name);
+        };
+
+        while (checkNameExists(newName)) {
+          nameCounter++;
+          newName = `${baseName} ${nameCounter}`;
+        }
+
+        const folderPath = `${parentPath}/${newName}`;
+        const folderId = folderPath;
+
+        const newFolder: FileNode = {
+          id: folderId,
+          name: newName,
+          type: 'folder',
+          path: folderPath,
+          children: [],
+        };
+
+        // Create on disk
+        invoke('create_folder', { path: folderPath })
+          .then(() => console.log('Folder created on disk:', folderPath))
+          .catch((err) => console.error('Failed to create folder:', err));
+
+        if (parentFolderId) {
+          // Add inside parent
+          const addToParent = (nodes: FileNode[]): FileNode[] => {
+            return nodes.map((node) => {
+              if (node.id === parentFolderId) {
+                return {
+                  ...node,
+                  children: [...(node.children || []), newFolder],
+                };
+              }
+              if (node.children) {
+                return { ...node, children: addToParent(node.children) };
+              }
+              return node;
+            });
+          };
+
+          const newExpandedFolderIds = state.expandedFolderIds.includes(
+            parentFolderId
+          )
+            ? state.expandedFolderIds
+            : [...state.expandedFolderIds, parentFolderId];
+
+          set({
+            files: addToParent(files),
+            expandedFolderIds: [...newExpandedFolderIds, folderId],
+          });
+        } else {
+          // Add at root
+          set({
+            files: [...files, newFolder],
+            expandedFolderIds: [...state.expandedFolderIds, folderId],
+          });
+        }
+      },
+
+      closeOtherFiles: (fileId: string) => {
+        const state = get();
+        set({
+          openFiles: state.openFiles.includes(fileId) ? [fileId] : [],
+          activeFileId: state.openFiles.includes(fileId) ? fileId : null,
+          activeFileContent:
+            state.activeFileId === fileId ? state.activeFileContent : '',
+        });
+        if (state.activeFileId !== fileId && state.openFiles.includes(fileId)) {
+          get().selectFile(fileId);
+        }
+      },
+
+      closeAllFiles: () => {
+        set({
+          openFiles: [],
+          activeFileId: null,
+          activeFileContent: '',
+        });
+      },
+    }),
+    {
+      name: 'cinder-app-storage',
+      partialize: (state) => ({
+        isAutoSave: state.isAutoSave,
+        pinnedFiles: state.pinnedFiles,
+      }),
     }
-  },
-
-  closeOtherFiles: (fileId: string) => {
-    const state = get();
-    set({
-      openFiles: state.openFiles.includes(fileId) ? [fileId] : [],
-      activeFileId: state.openFiles.includes(fileId) ? fileId : null,
-      activeFileContent:
-        state.activeFileId === fileId ? state.activeFileContent : '',
-    });
-    if (state.activeFileId !== fileId && state.openFiles.includes(fileId)) {
-      get().selectFile(fileId);
-    }
-  },
-
-  closeAllFiles: () => {
-    set({
-      openFiles: [],
-      activeFileId: null,
-      activeFileContent: '',
-    });
-  },
-}));
+  )
+);

--- a/src/util/contextMenu.ts
+++ b/src/util/contextMenu.ts
@@ -27,6 +27,7 @@ type StoreActions = {
   closeOtherFiles: (fileId: string) => void;
   closeAllFiles: () => void;
   findFile: (id: string) => FileNode | null;
+  togglePin: (fileId: string) => void;
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -61,6 +62,11 @@ export async function showFileContextMenu(
         id: 'rename',
         text: 'Rename',
         action: () => actions.setRenamingFileId(node.id, 'explorer'),
+      }),
+      await MenuItem.new({
+        id: 'pin',
+        text: 'Pin / Unpin',
+        action: () => actions.togglePin(node.id),
       }),
       await MenuItem.new({
         id: 'duplicate',
@@ -183,6 +189,11 @@ export async function showTabContextMenu(
       id: 'close',
       text: 'Close',
       action: () => actions.closeFile(fileId),
+    }),
+    await MenuItem.new({
+      id: 'pin',
+      text: 'Pin / Unpin',
+      action: () => actions.togglePin(fileId),
     }),
     await MenuItem.new({
       id: 'close-others',


### PR DESCRIPTION
## What does this PR do?

# PR Description: Reactive Sidebar Syncing & Pinned Notes

This PR introduces real-time file-system watching and the ability to pin notes to the sidebar, alongside UI cleanups.

## Key Changes

### 1. Real-Time Sidebar Syncing
*   **File Watching (Rust Backend):** Added the `notify` crate to watch the active workspace directory for filesystem changes, broadcasting a `workspace-changed` event via Tauri.
*   **Sidebar Reactivity (React Frontend):** Added a custom `useFileWatcher` hook to listen to the Tauri event and automatically refresh the file tree in the Zustand store.

### 2. Pinned Notes Feature
*   **Pinned Section:** Created a new "Pinned Notes" section at the top of the sidebar.
*   **Context Menus:** Added "Pin / Unpin" actions to both the file tree and editor tab context menus.
*   **Persistence:** Pinned notes state is stored and persisted across app restarts using Zustand's local storage middleware.
*   **UX Adjustments:** Disabled drag-and-drop operations on pinned shortcut items to maintain list stability.

### 3. Settings UI Cleanup
*   **Auto-Save:** Removed the redundant manual Auto-save toggle from the General Settings UI, as the application always auto-saves notes automatically in the background.

## Related issue

#32 


## Checklist

- [ -] I tested my changes
- [-] I didn’t break existing functionality
- [-] I followed repo style
