### PR TITLE
refactor(ui): minimize settings and trash pages

### DIFF
--- a/src/components/features/settings/Settings.tsx
+++ b/src/components/features/settings/Settings.tsx
@@ -1,16 +1,5 @@
 import { useState, useEffect } from 'react';
-import {
-  Sun,
-  Moon,
-  Monitor,
-  Lock,
-  Settings as SettingsIcon,
-  Palette,
-  Bell,
-  FolderOpen,
-  Globe,
-  ChevronDown,
-} from 'lucide-react';
+import { ChevronDown, Lock } from 'lucide-react';
 
 interface ThemePreset {
   id: string;
@@ -131,13 +120,11 @@ const THEME_VARIABLES = [
   '--activity-bar-bg',
 ];
 
+const MAIN_THEMES = ['cinder-dark', 'cinder-light', 'zen-black'];
+
 export function Settings() {
-  const [activeTab, setActiveTab] = useState<'general' | 'theme'>('general');
   const [currentTheme, setCurrentTheme] = useState(
     () => localStorage.getItem('cinder-theme') || ''
-  );
-  const [colorMode, setColorMode] = useState<'light' | 'dark' | 'system'>(
-    'dark'
   );
   const [showAllThemes, setShowAllThemes] = useState(false);
 
@@ -156,301 +143,74 @@ export function Settings() {
     localStorage.setItem('cinder-theme', currentTheme);
   }, [currentTheme]);
 
+  const renderThemeButton = (theme: ThemePreset) => {
+    const isActive = currentTheme === theme.value && !theme.disabled;
+    return (
+      <button
+        key={theme.id}
+        onClick={() => !theme.disabled && setCurrentTheme(theme.value || '')}
+        disabled={theme.disabled}
+        className={`relative flex items-center gap-3 p-3 rounded-lg border text-left transition-colors ${isActive ? 'bg-[var(--bg-tertiary)] border-[var(--editor-header-accent)]' : 'bg-[var(--bg-secondary)] border-[var(--border-primary)]'} ${!theme.disabled ? 'hover:bg-[var(--bg-hover)] cursor-pointer' : 'opacity-40 cursor-not-allowed'}`}
+      >
+        <div
+          className="w-8 h-8 rounded-full shrink-0"
+          style={{ background: theme.gradient }}
+        />
+        <span
+          className={`text-sm truncate ${isActive ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'}`}
+        >
+          {theme.name}
+        </span>
+        {theme.disabled && (
+          <Lock
+            size={12}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]"
+          />
+        )}
+      </button>
+    );
+  };
+
   return (
-    <div className="flex-1 flex justify-center h-full bg-[var(--bg-primary)] overflow-hidden">
-      <div className="w-full max-w-5xl flex h-full border-x border-[var(--border-primary)] shadow-sm">
-        {/* Sidebar-style Tabs */}
-        <div className="w-64 border-r border-[var(--border-primary)] bg-[var(--bg-secondary)] flex flex-col p-4 gap-2">
-          <h2 className="px-3 py-2 text-[10px] uppercase tracking-widest font-bold opacity-30">
-            Settings
-          </h2>
-          <button
-            onClick={() => setActiveTab('general')}
-            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${activeTab === 'general' ? 'bg-[var(--bg-active)] text-[var(--editor-header-accent)]' : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'}`}
-          >
-            <SettingsIcon size={16} />
-            General
-          </button>
-          <button
-            onClick={() => setActiveTab('theme')}
-            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${activeTab === 'theme' ? 'bg-[var(--bg-active)] text-[var(--editor-header-accent)]' : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'}`}
-          >
-            <Palette size={16} />
-            Appearance
-          </button>
-        </div>
+    <div className="flex-1 h-full bg-[var(--bg-primary)] overflow-y-auto no-scrollbar">
+      <div className="max-w-xl mx-auto px-8 py-10">
+        <h1 className="text-lg font-semibold text-[var(--text-primary)]">
+          Settings
+        </h1>
+        <p className="mt-1 text-xs text-[var(--text-tertiary)]">Appearance</p>
 
-        {/* Content Area */}
-        <div className="flex-1 overflow-y-auto p-8 no-scrollbar">
-          <div className="max-w-2xl mx-auto">
-            {activeTab === 'general' ? (
-              <div className="space-y-10">
-                <div className="pb-6 border-b border-[var(--border-primary)]">
-                  <h1 className="text-2xl font-bold text-[var(--text-primary)]">
-                    General Settings
-                  </h1>
-                  <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                    Customize your editor experience
-                  </p>
-                </div>
-
-                <div className="space-y-6">
-                  <h2 className="text-lg font-semibold text-[var(--text-primary)]">
-                    Editor
-                  </h2>
-                  <div className="space-y-3">
-                    {[
-                      {
-                        icon: Monitor,
-                        title: 'Default View',
-                        desc: 'Choose default view for new files',
-                        options: ['Split View', 'Editor Only', 'Preview Only'],
-                      },
-                      {
-                        icon: FolderOpen,
-                        title: 'Sidebar Position',
-                        desc: 'Change the location of the sidebar',
-                        options: ['Left', 'Right'],
-                      },
-                    ].map((item, idx) => (
-                      <div
-                        key={idx}
-                        className="flex items-center justify-between p-4 bg-[var(--bg-secondary)] rounded-lg border border-[var(--border-primary)]"
-                      >
-                        <div className="flex items-center gap-4">
-                          <div className="p-2 bg-[var(--bg-tertiary)] rounded-md text-[var(--text-secondary)]">
-                            <item.icon size={20} />
-                          </div>
-                          <div>
-                            <h3 className="text-sm font-medium text-[var(--text-primary)]">
-                              {item.title}
-                            </h3>
-                            <p className="text-xs text-[var(--text-secondary)]">
-                              {item.desc}
-                            </p>
-                          </div>
-                        </div>
-                        <select className="px-3 py-1.5 text-xs font-medium border border-[var(--border-secondary)] rounded hover:bg-[var(--bg-hover)] bg-[var(--bg-tertiary)] text-[var(--text-primary)] outline-none transition-all">
-                          {item.options.map((opt) => (
-                            <option key={opt} value={opt}>
-                              {opt}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    ))}
-                  </div>
-
-                  <h2 className="text-lg font-semibold text-[var(--text-primary)] mt-8">
-                    System
-                  </h2>
-                  <div className="space-y-3">
-                    {[
-                      {
-                        icon: Globe,
-                        title: 'Language',
-                        desc: 'Change interface language',
-                        options: [
-                          'English',
-                          'Spanish',
-                          'French',
-                          'German',
-                          'Japanese',
-                        ],
-                      },
-                      {
-                        icon: Bell,
-                        title: 'Notifications',
-                        desc: 'Configure desktop notifications',
-                        options: ['All', 'Important Only', 'None'],
-                      },
-                    ].map((item, idx) => (
-                      <div
-                        key={idx}
-                        className="flex items-center justify-between p-4 bg-[var(--bg-secondary)] rounded-lg border border-[var(--border-primary)]"
-                      >
-                        <div className="flex items-center gap-4">
-                          <div className="p-2 bg-[var(--bg-tertiary)] rounded-md text-[var(--text-secondary)]">
-                            <item.icon size={20} />
-                          </div>
-                          <div>
-                            <h3 className="text-sm font-medium text-[var(--text-primary)]">
-                              {item.title}
-                            </h3>
-                            <p className="text-xs text-[var(--text-secondary)]">
-                              {item.desc}
-                            </p>
-                          </div>
-                        </div>
-                        <select className="px-3 py-1.5 text-xs font-medium border border-[var(--border-secondary)] rounded hover:bg-[var(--bg-hover)] bg-[var(--bg-tertiary)] text-[var(--text-primary)] outline-none transition-all">
-                          {item.options.map((opt) => (
-                            <option key={opt} value={opt}>
-                              {opt}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-10">
-                <div className="pb-6 border-b border-[var(--border-primary)]">
-                  <h1 className="text-2xl font-bold text-[var(--text-primary)]">
-                    Themes
-                  </h1>
-                  <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                    Manage app appearance and customization
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  <h2 className="text-lg font-semibold text-[var(--text-primary)]">
-                    Color Mode
-                  </h2>
-                  <div className="flex gap-4">
-                    {[
-                      { id: 'light', label: 'Light mode', icon: Sun },
-                      { id: 'dark', label: 'Dark mode', icon: Moon },
-                      { id: 'system', label: 'System', icon: Monitor },
-                    ].map((mode) => (
-                      <button
-                        key={mode.id}
-                        onClick={() =>
-                          setColorMode(mode.id as 'light' | 'dark' | 'system')
-                        }
-                        className={`flex-1 flex items-center justify-center gap-3 p-4 rounded-lg border transition-all ${colorMode === mode.id ? 'bg-[var(--bg-tertiary)] border-[var(--editor-header-accent)] ring-1 ring-[var(--editor-header-accent)]' : 'bg-[var(--bg-secondary)] border-[var(--border-primary)] hover:bg-[var(--bg-hover)]'}`}
-                      >
-                        <mode.icon
-                          size={18}
-                          className={
-                            colorMode === mode.id
-                              ? 'text-[var(--editor-header-accent)]'
-                              : 'text-[var(--text-secondary)]'
-                          }
-                        />
-                        <span
-                          className={
-                            colorMode === mode.id
-                              ? 'font-medium text-[var(--text-primary)]'
-                              : 'text-[var(--text-secondary)]'
-                          }
-                        >
-                          {mode.label}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="space-y-4 pt-4">
-                  <h2 className="text-lg font-semibold text-[var(--text-primary)]">
-                    Main Themes
-                  </h2>
-                  <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-                    {THEME_PRESETS.filter((t) =>
-                      ['cinder-dark', 'cinder-light', 'zen-black'].includes(
-                        t.id
-                      )
-                    ).map((theme) => {
-                      const isActive =
-                        currentTheme === theme.value && !theme.disabled;
-                      return (
-                        <button
-                          key={theme.id}
-                          onClick={() =>
-                            !theme.disabled &&
-                            setCurrentTheme(theme.value || '')
-                          }
-                          disabled={theme.disabled}
-                          className={`relative flex items-center gap-3 p-3 rounded-xl border text-left transition-all ${isActive ? 'bg-[var(--bg-tertiary)] border-[var(--editor-header-accent)] shadow-sm' : 'bg-[var(--bg-secondary)] border-[var(--border-primary)]'} ${!theme.disabled ? 'hover:bg-[var(--bg-hover)] cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
-                        >
-                          <div
-                            className="w-10 h-10 rounded-full shrink-0 shadow-inner"
-                            style={{ background: theme.gradient }}
-                          />
-                          <div className="min-w-0">
-                            <div
-                              className={`text-sm font-medium truncate ${isActive ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'}`}
-                            >
-                              {theme.name}
-                            </div>
-                          </div>
-                          {theme.disabled && (
-                            <Lock
-                              size={14}
-                              className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] opacity-30"
-                            />
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-
-                  <div className="pt-4">
-                    <button
-                      onClick={() => setShowAllThemes(!showAllThemes)}
-                      className="flex items-center gap-2 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors mb-4 focus:outline-none"
-                    >
-                      <ChevronDown
-                        size={16}
-                        className={`transition-transform duration-200 ${showAllThemes ? 'rotate-180' : ''}`}
-                      />
-                      {showAllThemes
-                        ? 'Hide other themes'
-                        : 'Show other themes'}
-                    </button>
-
-                    {showAllThemes && (
-                      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 animate-in fade-in slide-in-from-top-2 duration-200">
-                        {THEME_PRESETS.filter(
-                          (t) =>
-                            ![
-                              'cinder-dark',
-                              'cinder-light',
-                              'zen-black',
-                            ].includes(t.id)
-                        ).map((theme) => {
-                          const isActive =
-                            currentTheme === theme.value && !theme.disabled;
-                          return (
-                            <button
-                              key={theme.id}
-                              onClick={() =>
-                                !theme.disabled &&
-                                setCurrentTheme(theme.value || '')
-                              }
-                              disabled={theme.disabled}
-                              className={`relative flex items-center gap-3 p-3 rounded-xl border text-left transition-all ${isActive ? 'bg-[var(--bg-tertiary)] border-[var(--editor-header-accent)] shadow-sm' : 'bg-[var(--bg-secondary)] border-[var(--border-primary)]'} ${!theme.disabled ? 'hover:bg-[var(--bg-hover)] cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
-                            >
-                              <div
-                                className="w-10 h-10 rounded-full shrink-0 shadow-inner"
-                                style={{ background: theme.gradient }}
-                              />
-                              <div className="min-w-0">
-                                <div
-                                  className={`text-sm font-medium truncate ${isActive ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'}`}
-                                >
-                                  {theme.name}
-                                </div>
-                              </div>
-                              {theme.disabled && (
-                                <Lock
-                                  size={14}
-                                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] opacity-30"
-                                />
-                              )}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+        {/* Theme grid */}
+        <div className="mt-8">
+          <span className="text-[11px] uppercase tracking-wider text-[var(--text-tertiary)] font-medium">
+            Themes
+          </span>
+          <div className="grid grid-cols-2 gap-3 mt-3">
+            {THEME_PRESETS.filter((t) => MAIN_THEMES.includes(t.id)).map(
+              renderThemeButton
             )}
           </div>
+        </div>
+
+        {/* Other themes */}
+        <div className="mt-6">
+          <button
+            onClick={() => setShowAllThemes(!showAllThemes)}
+            className="flex items-center gap-1.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+          >
+            <ChevronDown
+              size={14}
+              className={`transition-transform duration-200 ${showAllThemes ? 'rotate-180' : ''}`}
+            />
+            {showAllThemes ? 'Hide other themes' : 'More themes'}
+          </button>
+
+          {showAllThemes && (
+            <div className="grid grid-cols-2 gap-3 mt-3">
+              {THEME_PRESETS.filter((t) => !MAIN_THEMES.includes(t.id)).map(
+                renderThemeButton
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/features/trash/TrashView.tsx
+++ b/src/components/features/trash/TrashView.tsx
@@ -41,7 +41,6 @@ export function TrashView() {
       const entries = await invoke<TrashEntry[]>('list_trash', {
         workspacePath,
       });
-      // Sort by most recently trashed first
       entries.sort(
         (a, b) =>
           new Date(b.trashed_at).getTime() - new Date(a.trashed_at).getTime()
@@ -91,113 +90,95 @@ export function TrashView() {
   };
 
   return (
-    <div className="flex-1 flex justify-center h-full bg-[var(--bg-primary)] overflow-hidden">
-      <div className="w-full max-w-3xl flex flex-col h-full border-x border-[var(--border-primary)] shadow-sm">
+    <div className="flex-1 h-full bg-[var(--bg-primary)] overflow-y-auto no-scrollbar">
+      <div className="max-w-xl mx-auto px-8 py-10">
         {/* Header */}
-        <div className="shrink-0 p-8 pb-6 border-b border-[var(--border-primary)]">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-[var(--text-primary)]">
-                Trash
-              </h1>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                {items.length === 0
-                  ? 'No items in trash'
-                  : `${items.length} item${items.length !== 1 ? 's' : ''} in trash`}
-              </p>
-            </div>
-            {items.length > 0 && (
-              <button
-                onClick={handleEmptyTrash}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors hover:bg-[var(--bg-hover)] border border-[var(--border-primary)]"
-                style={{ color: 'var(--text-secondary)' }}
-                title="Permanently delete all items"
-              >
-                <Trash2 size={13} />
-                Empty Trash
-              </button>
-            )}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-semibold text-[var(--text-primary)]">
+              Trash
+            </h1>
+            <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+              {items.length === 0
+                ? 'No items'
+                : `${items.length} item${items.length !== 1 ? 's' : ''}`}
+            </p>
           </div>
+          {items.length > 0 && (
+            <button
+              onClick={handleEmptyTrash}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors"
+              title="Permanently delete all items"
+            >
+              <Trash2 size={12} />
+              Empty
+            </button>
+          )}
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto no-scrollbar">
+        <div className="mt-6">
           {loading ? (
-            <div className="flex items-center justify-center h-40">
-              <p className="text-sm text-[var(--text-tertiary)]">Loading...</p>
-            </div>
+            <p className="text-xs text-[var(--text-tertiary)] py-8 text-center">
+              Loading...
+            </p>
           ) : items.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full gap-4 opacity-40">
+            <div className="flex flex-col items-center py-16 opacity-30">
               <Trash2
-                size={48}
+                size={32}
                 strokeWidth={1}
-                style={{ color: 'var(--text-tertiary)' }}
+                className="text-[var(--text-tertiary)]"
               />
-              <p
-                className="text-sm font-medium"
-                style={{ color: 'var(--text-tertiary)' }}
-              >
+              <p className="text-xs text-[var(--text-tertiary)] mt-3">
                 Trash is empty
               </p>
             </div>
           ) : (
-            <div>
+            <div className="space-y-0.5">
               {items.map((entry) => (
                 <div
                   key={entry.id}
-                  className="flex items-center gap-4 px-8 py-3.5 border-b transition-colors hover:bg-[var(--bg-hover)] group"
-                  style={{ borderColor: 'var(--border-primary)' }}
+                  className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-[var(--bg-hover)] transition-colors group"
                 >
-                  {/* Icon */}
-                  <div
-                    className="p-2 rounded-lg shrink-0"
-                    style={{ backgroundColor: 'var(--bg-tertiary)' }}
-                  >
-                    {entry.entry_type === 'folder' ? (
-                      <Folder
-                        size={18}
-                        style={{ color: 'var(--text-secondary)' }}
-                      />
-                    ) : (
-                      <FileText
-                        size={18}
-                        style={{ color: 'var(--text-secondary)' }}
-                      />
-                    )}
-                  </div>
+                  {entry.entry_type === 'folder' ? (
+                    <Folder
+                      size={15}
+                      className="shrink-0 text-[var(--text-tertiary)]"
+                    />
+                  ) : (
+                    <FileText
+                      size={15}
+                      className="shrink-0 text-[var(--text-tertiary)]"
+                    />
+                  )}
 
-                  {/* Info */}
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate text-[var(--text-primary)]">
+                    <div className="text-sm truncate text-[var(--text-primary)]">
                       {entry.original_name}
                     </div>
-                    <div className="text-xs text-[var(--text-tertiary)] truncate mt-0.5">
+                    <div className="text-[11px] text-[var(--text-tertiary)] truncate">
                       {entry.relative_path}
                     </div>
                   </div>
 
-                  {/* Time */}
-                  <span className="text-[11px] text-[var(--text-tertiary)] shrink-0 tabular-nums">
+                  <span className="text-[10px] text-[var(--text-tertiary)] shrink-0 tabular-nums">
                     {timeAgo(entry.trashed_at)}
                   </span>
 
-                  {/* Actions */}
-                  <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button
                       onClick={() => handleRestore(entry)}
-                      className="p-1.5 rounded-md transition-colors hover:bg-[var(--bg-active)]"
-                      style={{ color: 'var(--text-secondary)' }}
-                      title="Restore to original location"
+                      className="p-1 rounded hover:bg-[var(--bg-active)] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+                      title="Restore"
                     >
-                      <RotateCcw size={14} />
+                      <RotateCcw size={13} />
                     </button>
                     <button
                       onClick={() => handleDelete(entry)}
-                      className="p-1.5 rounded-md transition-colors hover:bg-[var(--bg-active)]"
-                      style={{ color: 'var(--text-tertiary)' }}
+                      className="p-1 rounded hover:bg-[var(--bg-active)] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
                       title="Delete permanently"
                     >
-                      <X size={14} />
+                      <X size={13} />
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
Settings:
- Remove all fake/demo settings (Default View, Sidebar Position, Language, Notifications, Color Mode) that had no backing state
- Remove sidebar tab navigation (only one real section)
- Keep only theme selection which actually works
- Flat single-page layout, no bordered cards

Trash:
- Remove heavy bordered container and oversized icon backgrounds
- Tighter spacing, smaller icons, simpler row layout
- All functionality preserved (restore, delete, empty)

## What does this PR do?

-

## Related issue

Fixes #

## Checklist

- [ ] I tested my changes
- [ ] I didn’t break existing functionality
- [ ] I followed repo style
