### PR TITLE
Feature/split screen

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -41,14 +41,17 @@ test.describe('Editor and Tabs', () => {
     }
   });
 
-  test('fullscreen button is present', async ({ page }) => {
+  test('fullscreen button is only visible with multiple panes', async ({
+    page,
+  }) => {
     const hasLayout = await page
       .getByTestId('main-layout')
       .isVisible()
       .catch(() => false);
     if (hasLayout) {
+      // In a single-pane layout, fullscreen button should NOT be visible
       const fullscreenBtn = page.getByTestId('fullscreen-button');
-      await expect(fullscreenBtn).toBeVisible();
+      await expect(fullscreenBtn).not.toBeVisible();
     }
   });
 

--- a/e2e/split-screen.spec.ts
+++ b/e2e/split-screen.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '@playwright/test';
+import { resetApp } from './helpers';
+
+/**
+ * Helper: check if the main layout is visible (workspace loaded).
+ * Returns false if only the welcome page is shown.
+ */
+async function hasMainLayout(page: import('@playwright/test').Page) {
+  return page
+    .getByTestId('main-layout')
+    .isVisible()
+    .catch(() => false);
+}
+
+/**
+ * Trigger a horizontal split via keyboard shortcut (Cmd/Ctrl + \).
+ */
+async function splitHorizontal(page: import('@playwright/test').Page) {
+  const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+\\`);
+  await page.waitForTimeout(400);
+}
+
+/**
+ * Trigger a vertical split via keyboard shortcut (Cmd/Ctrl + Shift + \).
+ */
+async function splitVertical(page: import('@playwright/test').Page) {
+  const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+Shift+\\`);
+  await page.waitForTimeout(400);
+}
+
+test.describe('Split Screen', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetApp(page);
+    await page.waitForTimeout(2000);
+  });
+
+  // ─── Basic Split ───────────────────────────────────────────────────────
+
+  test('starts with a single editor pane', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    const panes = page.getByTestId('editor-pane');
+    await expect(panes).toHaveCount(1);
+  });
+
+  test('horizontal split creates two panes side by side', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    await splitHorizontal(page);
+
+    const panes = page.getByTestId('editor-pane');
+    await expect(panes).toHaveCount(2);
+  });
+
+  test('vertical split creates two panes stacked', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    await splitVertical(page);
+
+    const panes = page.getByTestId('editor-pane');
+    await expect(panes).toHaveCount(2);
+  });
+
+  // ─── 4-Quadrant Limit ─────────────────────────────────────────────────
+
+  test('can split into four quadrants maximum', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    // Split horizontally first (2 panes)
+    await splitHorizontal(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(2);
+
+    // Split vertically (3 panes)
+    await splitVertical(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(3);
+
+    // Click into the other pane and split it too (4 panes)
+    const panes = page.getByTestId('editor-pane');
+    await panes.first().click();
+    await page.waitForTimeout(200);
+    await splitVertical(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(4);
+  });
+
+  test('cannot split beyond four panes', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    // Create 4 panes
+    await splitHorizontal(page);
+    await splitVertical(page);
+    const panes = page.getByTestId('editor-pane');
+    await panes.first().click();
+    await page.waitForTimeout(200);
+    await splitVertical(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(4);
+
+    // Try to split again -- should stay at 4
+    await splitHorizontal(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(4);
+
+    await splitVertical(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(4);
+  });
+
+  // ─── Split UI Elements ────────────────────────────────────────────────
+
+  test('resize handle appears between split panes', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    // No resize handle in single-pane mode
+    await expect(page.getByTestId('split-resize-handle')).toHaveCount(0);
+
+    await splitHorizontal(page);
+
+    // Resize handle should now be visible
+    const handle = page.getByTestId('split-resize-handle');
+    await expect(handle.first()).toBeVisible();
+  });
+
+  test('split container appears after splitting', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    // Before split: no split-container (root is a leaf = single EditorPane)
+    await expect(page.getByTestId('split-container')).toHaveCount(0);
+
+    await splitHorizontal(page);
+
+    // After split: at least one split-container should exist
+    await expect(page.getByTestId('split-container').first()).toBeVisible();
+  });
+
+  // ─── Multi-Pane Tab Controls ──────────────────────────────────────────
+
+  test('close-pane and fullscreen buttons appear after split', async ({
+    page,
+  }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    // Before split: these buttons should not exist
+    await expect(page.getByTestId('close-pane-button')).toHaveCount(0);
+    await expect(page.getByTestId('fullscreen-button')).toHaveCount(0);
+
+    await splitHorizontal(page);
+
+    // After split: both panes should have close and fullscreen buttons
+    await expect(page.getByTestId('close-pane-button').first()).toBeVisible();
+    await expect(page.getByTestId('fullscreen-button').first()).toBeVisible();
+  });
+
+  test('closing a pane returns to single-pane layout', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    await splitHorizontal(page);
+    await expect(page.getByTestId('editor-pane')).toHaveCount(2);
+
+    // Close the active pane
+    await page.getByTestId('close-pane-button').first().click();
+    await page.waitForTimeout(300);
+
+    // Should be back to a single pane
+    await expect(page.getByTestId('editor-pane')).toHaveCount(1);
+
+    // Close/fullscreen buttons should disappear
+    await expect(page.getByTestId('close-pane-button')).toHaveCount(0);
+    await expect(page.getByTestId('fullscreen-button')).toHaveCount(0);
+  });
+
+  // ─── Each Pane Has Its Own Tabs ────────────────────────────────────────
+
+  test('each pane has its own tab bar', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    await splitHorizontal(page);
+
+    // There should be two tab bars
+    const tabBars = page.getByTestId('editor-tabs');
+    await expect(tabBars).toHaveCount(2);
+  });
+
+  test('each pane has its own new-tab button', async ({ page }) => {
+    if (!(await hasMainLayout(page))) return;
+
+    await splitHorizontal(page);
+
+    const newTabButtons = page.getByTestId('new-tab-button');
+    await expect(newTabButtons).toHaveCount(2);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState, useRef, useMemo } from 'react';
 import './App.css';
 import { MainLayout } from './components/layout/MainLayout';
 import { FileExplorer } from './components/layout/explorer/FileExplorer';
-import { EditorPane } from './components/layout/editor/EditorPane';
+import { SplitContainer } from './components/layout/editor/SplitContainer';
 
 import { SearchPanel } from './components/features/SearchPanel';
 import { WorkspaceWelcome } from './components/onboarding/WorkspaceWelcome';
 import { useAppStore } from './store/useAppStore';
+import { useSplitStore } from './store/useSplitStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useFileWatcher } from './hooks/useFileWatcher';
 import { useWorkspace } from './hooks/useWorkspace';
@@ -64,6 +65,14 @@ function App() {
 
   // Watch workspace directory for external file changes
   useFileWatcher();
+
+  // Reset split panes when workspace changes
+  useEffect(() => {
+    useSplitStore.getState().resetToSinglePane();
+  }, [workspacePath]);
+
+  // Get the split tree root (must be before early returns)
+  const rootNode = useSplitStore((state) => state.rootNode);
 
   // Global window drag handler - uses Tauri JS API since CSS app-region
   // doesn't work reliably with transparent overlay windows on macOS
@@ -179,7 +188,7 @@ function App() {
     <>
       <MainLayout
         sidebarContent={<FileExplorer />}
-        editorContent={<EditorPane />}
+        editorContent={<SplitContainer node={rootNode} />}
       />
 
       <SearchPanel />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ function App() {
 
   // Get the split tree root (must be before early returns)
   const rootNode = useSplitStore((state) => state.rootNode);
+  const maximizedPaneId = useSplitStore((state) => state.maximizedPaneId);
 
   // Global window drag handler - uses Tauri JS API since CSS app-region
   // doesn't work reliably with transparent overlay windows on macOS
@@ -188,7 +189,13 @@ function App() {
     <>
       <MainLayout
         sidebarContent={<FileExplorer />}
-        editorContent={<SplitContainer node={rootNode} />}
+        editorContent={
+          maximizedPaneId ? (
+            <SplitContainer node={{ type: 'leaf', paneId: maximizedPaneId }} />
+          ) : (
+            <SplitContainer node={rootNode} />
+          )
+        }
       />
 
       <SearchPanel />

--- a/src/__tests__/components/EditorTabs.test.tsx
+++ b/src/__tests__/components/EditorTabs.test.tsx
@@ -1,28 +1,27 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { EditorTabs } from '../../components/layout/editor/EditorTabs';
 import { useAppStore } from '../../store/useAppStore';
+import { useSplitStore } from '../../store/useSplitStore';
 
 // Mock dependencies
 vi.mock('../../store/useAppStore');
+vi.mock('../../store/useSplitStore');
 vi.mock('../../util/contextMenu', () => ({
   showTabContextMenu: vi.fn(),
 }));
 
 const mockUseAppStore = vi.mocked(useAppStore);
+const mockUseSplitStore = vi.mocked(useSplitStore);
 
-function createMockStoreReturn(overrides: Record<string, unknown> = {}) {
+const TEST_PANE_ID = 'pane-test';
+
+function createMockAppStoreReturn(overrides: Record<string, unknown> = {}) {
   return {
-    openFiles: [],
-    activeFileId: null,
-    selectFile: vi.fn(),
-    closeFile: vi.fn(),
     findFile: vi.fn(() => null),
-    createNewTab: vi.fn(),
     toggleExplorerCollapsed: vi.fn(),
     isExplorerCollapsed: false,
-    openFileInNewTab: vi.fn(),
     setRenamingFileId: vi.fn(),
     deleteFile: vi.fn(),
     deleteFolder: vi.fn(),
@@ -30,11 +29,26 @@ function createMockStoreReturn(overrides: Record<string, unknown> = {}) {
     createFile: vi.fn(),
     createFileInFolder: vi.fn(),
     createFolder: vi.fn(),
-    closeOtherFiles: vi.fn(),
-    closeAllFiles: vi.fn(),
     togglePin: vi.fn(),
     ...overrides,
   };
+}
+
+function createMockSplitStoreReturn(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    panes: {
+      [TEST_PANE_ID]: {
+        openFiles: [] as string[],
+        activeFileId: null as string | null,
+        activeFileContent: '',
+      },
+    },
+    rootNode: { type: 'leaf' as const, paneId: TEST_PANE_ID },
+    ...overrides,
+  };
+
+  // useSplitStore is called with a selector, so we mock it to invoke the selector
+  return (selector: (state: typeof defaults) => unknown) => selector(defaults);
 }
 
 describe('EditorTabs', () => {
@@ -43,47 +57,65 @@ describe('EditorTabs', () => {
   });
 
   it('renders an empty tab bar when no files are open', () => {
-    mockUseAppStore.mockReturnValue(createMockStoreReturn());
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(createMockSplitStoreReturn() as any);
 
-    render(<EditorTabs />);
-    // Should have the New Tab and Sidebar Toggle buttons
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByTitle('New Tab')).toBeInTheDocument();
     expect(screen.getByTitle('Toggle Sidebar')).toBeInTheDocument();
   });
 
   it('renders a welcome tab correctly', () => {
-    mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({
-        openFiles: ['welcome'],
-        activeFileId: 'welcome',
-      })
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        panes: {
+          [TEST_PANE_ID]: {
+            openFiles: ['welcome'],
+            activeFileId: 'welcome',
+            activeFileContent: '',
+          },
+        },
+      }) as any
     );
 
-    render(<EditorTabs />);
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByText('Welcome')).toBeInTheDocument();
   });
 
   it('renders a blank "Untitled" tab', () => {
-    mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({
-        openFiles: ['new-tab-1'],
-        activeFileId: 'new-tab-1',
-      })
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        panes: {
+          [TEST_PANE_ID]: {
+            openFiles: ['new-tab-1'],
+            activeFileId: 'new-tab-1',
+            activeFileContent: '',
+          },
+        },
+      }) as any
     );
 
-    render(<EditorTabs />);
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByText('Untitled')).toBeInTheDocument();
   });
 
   it('renders system tabs with correct names', () => {
-    mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({
-        openFiles: ['cinder-settings', 'cinder-info', 'cinder-trash'],
-        activeFileId: 'cinder-settings',
-      })
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        panes: {
+          [TEST_PANE_ID]: {
+            openFiles: ['cinder-settings', 'cinder-info', 'cinder-trash'],
+            activeFileId: 'cinder-settings',
+            activeFileContent: '',
+          },
+        },
+      }) as any
     );
 
-    render(<EditorTabs />);
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.getByText('About')).toBeInTheDocument();
     expect(screen.getByText('Trash')).toBeInTheDocument();
@@ -91,9 +123,7 @@ describe('EditorTabs', () => {
 
   it('renders a regular file tab with the name from findFile (without .md)', () => {
     mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({
-        openFiles: ['/workspace/notes.md'],
-        activeFileId: '/workspace/notes.md',
+      createMockAppStoreReturn({
         findFile: vi.fn((id: string) =>
           id === '/workspace/notes.md'
             ? { id, name: 'notes.md', type: 'file' as const, path: id }
@@ -101,67 +131,47 @@ describe('EditorTabs', () => {
         ),
       })
     );
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        panes: {
+          [TEST_PANE_ID]: {
+            openFiles: ['/workspace/notes.md'],
+            activeFileId: '/workspace/notes.md',
+            activeFileContent: '',
+          },
+        },
+      }) as any
+    );
 
-    render(<EditorTabs />);
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByText('notes')).toBeInTheDocument();
   });
 
-  it('calls selectFile when a tab is clicked', async () => {
-    const selectFile = vi.fn();
-    mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({
-        openFiles: ['welcome'],
-        activeFileId: 'welcome',
-        selectFile,
-      })
-    );
+  it('shows "Toggle Sidebar" button', () => {
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(createMockSplitStoreReturn() as any);
 
-    const user = userEvent.setup();
-    render(<EditorTabs />);
-
-    await user.click(screen.getByText('Welcome'));
-    expect(selectFile).toHaveBeenCalledWith('welcome');
-  });
-
-  it('calls createNewTab when the "New Tab" button is clicked', async () => {
-    const createNewTab = vi.fn();
-    mockUseAppStore.mockReturnValue(createMockStoreReturn({ createNewTab }));
-
-    const user = userEvent.setup();
-    render(<EditorTabs />);
-
-    await user.click(screen.getByTitle('New Tab'));
-    expect(createNewTab).toHaveBeenCalledOnce();
-  });
-
-  it('calls toggleExplorerCollapsed when the "Toggle Sidebar" button is clicked', async () => {
-    const toggleExplorerCollapsed = vi.fn();
-    mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({ toggleExplorerCollapsed })
-    );
-
-    const user = userEvent.setup();
-    render(<EditorTabs />);
-
-    await user.click(screen.getByTitle('Toggle Sidebar'));
-    expect(toggleExplorerCollapsed).toHaveBeenCalledOnce();
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
+    expect(screen.getByTitle('Toggle Sidebar')).toBeInTheDocument();
   });
 
   it('shows "Exit Fullscreen" title when explorer is collapsed', () => {
     mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({ isExplorerCollapsed: true })
+      createMockAppStoreReturn({ isExplorerCollapsed: true })
     );
+    mockUseSplitStore.mockImplementation(createMockSplitStoreReturn() as any);
 
-    render(<EditorTabs />);
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByTitle('Exit Fullscreen')).toBeInTheDocument();
   });
 
   it('shows "Fullscreen Editor" title when explorer is not collapsed', () => {
     mockUseAppStore.mockReturnValue(
-      createMockStoreReturn({ isExplorerCollapsed: false })
+      createMockAppStoreReturn({ isExplorerCollapsed: false })
     );
+    mockUseSplitStore.mockImplementation(createMockSplitStoreReturn() as any);
 
-    render(<EditorTabs />);
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByTitle('Fullscreen Editor')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/EditorTabs.test.tsx
+++ b/src/__tests__/components/EditorTabs.test.tsx
@@ -11,6 +11,9 @@ vi.mock('../../store/useSplitStore');
 vi.mock('../../util/contextMenu', () => ({
   showTabContextMenu: vi.fn(),
 }));
+vi.mock('../../util/dragContext', () => ({
+  setCurrentDrag: vi.fn(),
+}));
 
 const mockUseAppStore = vi.mocked(useAppStore);
 const mockUseSplitStore = vi.mocked(useSplitStore);
@@ -44,6 +47,7 @@ function createMockSplitStoreReturn(overrides: Record<string, unknown> = {}) {
       },
     },
     rootNode: { type: 'leaf' as const, paneId: TEST_PANE_ID },
+    maximizedPaneId: null as string | null,
     ...overrides,
   };
 
@@ -63,24 +67,6 @@ describe('EditorTabs', () => {
     render(<EditorTabs paneId={TEST_PANE_ID} />);
     expect(screen.getByTitle('New Tab')).toBeInTheDocument();
     expect(screen.getByTitle('Toggle Sidebar')).toBeInTheDocument();
-  });
-
-  it('renders a welcome tab correctly', () => {
-    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
-    mockUseSplitStore.mockImplementation(
-      createMockSplitStoreReturn({
-        panes: {
-          [TEST_PANE_ID]: {
-            openFiles: ['welcome'],
-            activeFileId: 'welcome',
-            activeFileContent: '',
-          },
-        },
-      }) as any
-    );
-
-    render(<EditorTabs paneId={TEST_PANE_ID} />);
-    expect(screen.getByText('Welcome')).toBeInTheDocument();
   });
 
   it('renders a blank "Untitled" tab', () => {
@@ -155,23 +141,74 @@ describe('EditorTabs', () => {
     expect(screen.getByTitle('Toggle Sidebar')).toBeInTheDocument();
   });
 
-  it('shows "Exit Fullscreen" title when explorer is collapsed', () => {
-    mockUseAppStore.mockReturnValue(
-      createMockAppStoreReturn({ isExplorerCollapsed: true })
+  it('shows "Close Pane" and "Maximize Pane" buttons when multiple panes exist', () => {
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        rootNode: {
+          type: 'branch' as const,
+          axis: 'horizontal',
+          children: [
+            { type: 'leaf' as const, paneId: TEST_PANE_ID },
+            { type: 'leaf' as const, paneId: 'pane-other' },
+          ],
+          flexes: [0.5, 0.5],
+        },
+      }) as any
     );
-    mockUseSplitStore.mockImplementation(createMockSplitStoreReturn() as any);
 
     render(<EditorTabs paneId={TEST_PANE_ID} />);
-    expect(screen.getByTitle('Exit Fullscreen')).toBeInTheDocument();
+    expect(screen.getByTitle('Close Pane')).toBeInTheDocument();
+    expect(screen.getByTitle('Maximize Pane')).toBeInTheDocument();
   });
 
-  it('shows "Fullscreen Editor" title when explorer is not collapsed', () => {
-    mockUseAppStore.mockReturnValue(
-      createMockAppStoreReturn({ isExplorerCollapsed: false })
+  it('shows "Restore Split" title when pane is maximized', () => {
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        rootNode: {
+          type: 'branch' as const,
+          axis: 'horizontal',
+          children: [
+            { type: 'leaf' as const, paneId: TEST_PANE_ID },
+            { type: 'leaf' as const, paneId: 'pane-other' },
+          ],
+          flexes: [0.5, 0.5],
+        },
+        maximizedPaneId: TEST_PANE_ID,
+      }) as any
     );
+
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
+    expect(screen.getByTitle('Restore Split')).toBeInTheDocument();
+  });
+
+  it('does not show "Close Pane" when there is a single pane', () => {
+    mockUseAppStore.mockReturnValue(createMockAppStoreReturn());
     mockUseSplitStore.mockImplementation(createMockSplitStoreReturn() as any);
 
     render(<EditorTabs paneId={TEST_PANE_ID} />);
-    expect(screen.getByTitle('Fullscreen Editor')).toBeInTheDocument();
+    expect(screen.queryByTitle('Close Pane')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Maximize Pane')).not.toBeInTheDocument();
+  });
+
+  it('renders an unknown file as "Unknown" when findFile returns null', () => {
+    mockUseAppStore.mockReturnValue(
+      createMockAppStoreReturn({ findFile: vi.fn(() => null) })
+    );
+    mockUseSplitStore.mockImplementation(
+      createMockSplitStoreReturn({
+        panes: {
+          [TEST_PANE_ID]: {
+            openFiles: ['nonexistent-file'],
+            activeFileId: 'nonexistent-file',
+            activeFileContent: '',
+          },
+        },
+      }) as any
+    );
+
+    render(<EditorTabs paneId={TEST_PANE_ID} />);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
   });
 });

--- a/src/components/layout/editor/Editor.tsx
+++ b/src/components/layout/editor/Editor.tsx
@@ -1,5 +1,6 @@
 import type { MutableRefObject } from 'react';
 import { useAppStore } from '../../../store/useAppStore';
+import { useSplitStore } from '../../../store/useSplitStore';
 import { MarkdownPreview } from './MarkdownPreview';
 
 import { Settings } from '../../features/settings/Settings';
@@ -9,6 +10,7 @@ import { CodeMirrorEditor } from './CodeMirrorEditor';
 import type { EditorView } from '@codemirror/view';
 
 interface EditorProps {
+  paneId: string;
   isPreview: boolean;
   onPreviewChange?: (isPreview: boolean) => void;
   editorViewRef?: MutableRefObject<EditorView | null>;
@@ -16,11 +18,17 @@ interface EditorProps {
 }
 
 export function Editor({
+  paneId,
   isPreview,
   editorViewRef,
   onCursorChange,
 }: EditorProps) {
-  const { activeFileId, activeFileContent, updateFileContent } = useAppStore();
+  const activeFileId = useSplitStore(
+    (state) => state.panes[paneId]?.activeFileId ?? null
+  );
+  const activeFileContent = useSplitStore(
+    (state) => state.panes[paneId]?.activeFileContent ?? ''
+  );
   const isMac = navigator.userAgent.includes('Mac');
 
   return (
@@ -145,7 +153,11 @@ export function Editor({
           ) : (
             <CodeMirrorEditor
               value={activeFileContent}
-              onChange={(val) => updateFileContent(activeFileId, val)}
+              onChange={(val) =>
+                useSplitStore
+                  .getState()
+                  .paneUpdateFileContent(paneId, activeFileId!, val)
+              }
               editorViewRef={editorViewRef}
               onCursorChange={onCursorChange}
             />

--- a/src/components/layout/editor/EditorHeader.tsx
+++ b/src/components/layout/editor/EditorHeader.tsx
@@ -1,22 +1,27 @@
 import { useRef, useEffect, type MutableRefObject } from 'react';
 import { Undo2, Redo2, Eye, Edit2 } from 'lucide-react';
 import { useAppStore } from '../../../store/useAppStore';
+import { useSplitStore } from '../../../store/useSplitStore';
 import { undo, redo } from '@codemirror/commands';
 import type { EditorView } from '@codemirror/view';
 
 interface EditorHeaderProps {
+  paneId: string;
   isPreview: boolean;
   onPreviewToggle: () => void;
   editorViewRef?: MutableRefObject<EditorView | null>;
 }
 
 export function EditorHeader({
+  paneId,
   isPreview,
   onPreviewToggle,
   editorViewRef,
 }: EditorHeaderProps) {
+  const activeFileId = useSplitStore(
+    (state) => state.panes[paneId]?.activeFileId ?? null
+  );
   const {
-    activeFileId,
     getFileBreadcrumb,
     renamingFileId,
     pendingFileId,

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -3,6 +3,7 @@ import { Editor } from './Editor';
 import { EditorTabs } from './EditorTabs';
 import { EditorHeader } from './EditorHeader';
 import { WelcomePage } from '../WelcomePage';
+import { useAppStore } from '../../../store/useAppStore';
 import { useSplitStore } from '../../../store/useSplitStore';
 import type { EditorView } from '@codemirror/view';
 
@@ -95,7 +96,14 @@ export function EditorPane({ paneId }: EditorPaneProps) {
       }
     }
 
+    const appStore = useAppStore.getState();
     const splitStore = useSplitStore.getState();
+
+    // Prevent dragging folders
+    const fileNode = appStore.findFile(fileId);
+    if (fileNode?.type === 'folder') {
+      return;
+    }
 
     if (zone === 'center') {
       // Drop into center

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -3,28 +3,53 @@ import { Editor } from './Editor';
 import { EditorTabs } from './EditorTabs';
 import { EditorHeader } from './EditorHeader';
 import { WelcomePage } from '../WelcomePage';
-import { useAppStore } from '../../../store/useAppStore';
+import { useSplitStore } from '../../../store/useSplitStore';
 import type { EditorView } from '@codemirror/view';
 
-export function EditorPane() {
+interface EditorPaneProps {
+  paneId: string;
+}
+
+export function EditorPane({ paneId }: EditorPaneProps) {
   const [isPreview, setIsPreview] = useState(false);
-  const { activeFileId } = useAppStore();
+  const activeFileId = useSplitStore(
+    (state) => state.panes[paneId]?.activeFileId ?? null
+  );
+  const isActivePane = useSplitStore((state) => state.activePaneId === paneId);
   const editorViewRef = useRef<EditorView | null>(null);
 
+  const handlePaneClick = () => {
+    useSplitStore.getState().setActivePaneId(paneId);
+  };
+
   return (
-    <div className="flex flex-col h-full w-full" data-testid="editor-pane">
-      <EditorTabs />
+    <div
+      className="flex flex-col h-full w-full"
+      data-testid="editor-pane"
+      onMouseDown={handlePaneClick}
+      style={{
+        borderTop: isActivePane
+          ? '2px solid var(--editor-header-accent)'
+          : '2px solid transparent',
+      }}
+    >
+      <EditorTabs paneId={paneId} />
       {activeFileId === 'welcome' ? (
         <WelcomePage />
       ) : (
         <>
           <EditorHeader
+            paneId={paneId}
             isPreview={isPreview}
             onPreviewToggle={() => setIsPreview(!isPreview)}
             editorViewRef={editorViewRef}
           />
           <div className="flex-1 min-h-0 relative">
-            <Editor isPreview={isPreview} editorViewRef={editorViewRef} />
+            <Editor
+              paneId={paneId}
+              isPreview={isPreview}
+              editorViewRef={editorViewRef}
+            />
           </div>
         </>
       )}

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -51,8 +51,9 @@ export function EditorPane({ paneId }: EditorPaneProps) {
   };
 
   const handleDragOver = (e: React.DragEvent) => {
-    const dragData = e.dataTransfer.types.includes('application/cinder-tab');
-    if (!dragData) return;
+    const hasTab = e.dataTransfer.types.includes('application/cinder-tab');
+    const hasFile = e.dataTransfer.types.includes('text/plain');
+    if (!hasTab && !hasFile) return;
 
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
@@ -68,25 +69,39 @@ export function EditorPane({ paneId }: EditorPaneProps) {
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    const raw = e.dataTransfer.getData('application/cinder-tab');
-    if (!raw) {
-      setDropZone(null);
-      return;
-    }
-
-    const { fileId, sourcePaneId } = JSON.parse(raw) as {
-      fileId: string;
-      sourcePaneId: string;
-    };
     const zone = getDropZone(e);
     setDropZone(null);
+
+    let fileId: string;
+    let sourcePaneId: string | null = null;
+
+    const rawTab = e.dataTransfer.getData('application/cinder-tab');
+    if (rawTab) {
+      const data = JSON.parse(rawTab) as {
+        fileId: string;
+        sourcePaneId: string;
+      };
+      fileId = data.fileId;
+      sourcePaneId = data.sourcePaneId;
+    } else {
+      const rawFile = e.dataTransfer.getData('text/plain');
+      if (rawFile) {
+        fileId = rawFile; // Dragged from sidebar
+      } else {
+        return;
+      }
+    }
 
     const splitStore = useSplitStore.getState();
 
     if (!zone) {
-      // Drop into center = move tab to this pane
-      if (sourcePaneId !== paneId) {
+      // Drop into center
+      if (sourcePaneId && sourcePaneId !== paneId) {
+        // Move tab from another pane
         splitStore.paneCloseFile(sourcePaneId, fileId);
+        splitStore.paneSelectFile(paneId, fileId);
+      } else if (!sourcePaneId) {
+        // Dropped from sidebar into center, just open it in this pane
         splitStore.paneSelectFile(paneId, fileId);
       }
       return;
@@ -101,7 +116,7 @@ export function EditorPane({ paneId }: EditorPaneProps) {
       paneId,
       axis,
       fileId,
-      sourcePaneId,
+      sourcePaneId || paneId, // If from sidebar, source is null, so just use current paneId as dummy
       insertBefore
     );
   };

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -10,7 +10,7 @@ interface EditorPaneProps {
   paneId: string;
 }
 
-type DropZone = 'left' | 'right' | 'top' | 'bottom' | null;
+type DropZone = 'left' | 'right' | 'top' | 'bottom' | 'center' | null;
 
 export function EditorPane({ paneId }: EditorPaneProps) {
   const [isPreview, setIsPreview] = useState(false);
@@ -47,7 +47,7 @@ export function EditorPane({ paneId }: EditorPaneProps) {
     if (x > w - edgeX) return 'right';
     if (y < edgeY) return 'top';
     if (y > h - edgeY) return 'bottom';
-    return null; // center = drop into this pane's tabs
+    return 'center';
   };
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -94,7 +94,7 @@ export function EditorPane({ paneId }: EditorPaneProps) {
 
     const splitStore = useSplitStore.getState();
 
-    if (!zone) {
+    if (zone === 'center') {
       // Drop into center
       if (sourcePaneId && sourcePaneId !== paneId) {
         // Move tab from another pane
@@ -168,6 +168,7 @@ export function EditorPane({ paneId }: EditorPaneProps) {
           right: '4px',
           height: '48%',
         };
+      case 'center':
       default:
         return undefined;
     }
@@ -193,6 +194,20 @@ export function EditorPane({ paneId }: EditorPaneProps) {
         outlineOffset: '-1px',
       }}
     >
+      {/* Invisible full-pane cover to intercept drops before CodeMirror */}
+      {dropZone && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 40,
+          }}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          onDragLeave={handleDragLeave}
+        />
+      )}
+      {/* Visual highlight overlay */}
       {overlayStyle && <div style={overlayStyle} />}
       <EditorTabs paneId={paneId} />
       {activeFileId === 'welcome' ? (

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -4,7 +4,8 @@ import { EditorTabs } from './EditorTabs';
 import { EditorHeader } from './EditorHeader';
 import { WelcomePage } from '../WelcomePage';
 import { useAppStore } from '../../../store/useAppStore';
-import { useSplitStore } from '../../../store/useSplitStore';
+import { useSplitStore, collectPaneIds } from '../../../store/useSplitStore';
+import { getCurrentDrag } from '../../../util/dragContext';
 import type { EditorView } from '@codemirror/view';
 
 interface EditorPaneProps {
@@ -56,10 +57,32 @@ export function EditorPane({ paneId }: EditorPaneProps) {
     const hasFile = e.dataTransfer.types.includes('text/plain');
     if (!hasTab && !hasFile) return;
 
+    const drag = getCurrentDrag();
+
+    // Don't show any overlay for folders -- they can't be opened as tabs
+    if (drag?.isFolder) return;
+
+    // Don't show overlay when dragging a tab within the same pane
+    // (same file, same source pane)
+    if (drag && drag.sourcePaneId === paneId) return;
+
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.dropEffect = 'move';
-    setDropZone(getDropZone(e));
+
+    const zone = getDropZone(e);
+
+    // If we already have 4 panes (max quadrants), only allow center drops
+    // (edge drops would create a split that the store will reject)
+    if (zone !== 'center') {
+      const { rootNode } = useSplitStore.getState();
+      if (collectPaneIds(rootNode).length >= 4) {
+        setDropZone('center');
+        return;
+      }
+    }
+
+    setDropZone(zone);
   };
 
   const handleDragLeave = (e: React.DragEvent) => {

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -10,29 +10,175 @@ interface EditorPaneProps {
   paneId: string;
 }
 
+type DropZone = 'left' | 'right' | 'top' | 'bottom' | null;
+
 export function EditorPane({ paneId }: EditorPaneProps) {
   const [isPreview, setIsPreview] = useState(false);
+  const [dropZone, setDropZone] = useState<DropZone>(null);
   const activeFileId = useSplitStore(
     (state) => state.panes[paneId]?.activeFileId ?? null
   );
   const isActivePane = useSplitStore((state) => state.activePaneId === paneId);
+  const hasMultiplePanes = useSplitStore(
+    (state) => state.rootNode.type === 'branch'
+  );
   const editorViewRef = useRef<EditorView | null>(null);
+  const paneRef = useRef<HTMLDivElement>(null);
 
   const handlePaneClick = () => {
     useSplitStore.getState().setActivePaneId(paneId);
   };
 
+  // ─── Drop zone detection ──────────────────────────────────────────────
+  const getDropZone = (e: React.DragEvent): DropZone => {
+    const rect = paneRef.current?.getBoundingClientRect();
+    if (!rect) return null;
+
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const w = rect.width;
+    const h = rect.height;
+
+    // Edge threshold: 25% of the pane dimension
+    const edgeX = w * 0.25;
+    const edgeY = h * 0.25;
+
+    if (x < edgeX) return 'left';
+    if (x > w - edgeX) return 'right';
+    if (y < edgeY) return 'top';
+    if (y > h - edgeY) return 'bottom';
+    return null; // center = drop into this pane's tabs
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    const dragData = e.dataTransfer.types.includes('application/cinder-tab');
+    if (!dragData) return;
+
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDropZone(getDropZone(e));
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    // Only reset if we're actually leaving the pane (not entering a child)
+    if (paneRef.current && !paneRef.current.contains(e.relatedTarget as Node)) {
+      setDropZone(null);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const raw = e.dataTransfer.getData('application/cinder-tab');
+    if (!raw) {
+      setDropZone(null);
+      return;
+    }
+
+    const { fileId, sourcePaneId } = JSON.parse(raw) as {
+      fileId: string;
+      sourcePaneId: string;
+    };
+    const zone = getDropZone(e);
+    setDropZone(null);
+
+    const splitStore = useSplitStore.getState();
+
+    if (!zone) {
+      // Drop into center = move tab to this pane
+      if (sourcePaneId !== paneId) {
+        splitStore.paneCloseFile(sourcePaneId, fileId);
+        splitStore.paneSelectFile(paneId, fileId);
+      }
+      return;
+    }
+
+    // Drop on edge = create a new split
+    const axis: 'horizontal' | 'vertical' =
+      zone === 'left' || zone === 'right' ? 'horizontal' : 'vertical';
+    const insertBefore = zone === 'left' || zone === 'top';
+
+    splitStore.splitPaneWithFile(
+      paneId,
+      axis,
+      fileId,
+      sourcePaneId,
+      insertBefore
+    );
+  };
+
+  // ─── Drop zone overlay indicator ──────────────────────────────────────
+  const dropOverlayStyle = (): React.CSSProperties | undefined => {
+    if (!dropZone) return undefined;
+
+    const base: React.CSSProperties = {
+      position: 'absolute',
+      backgroundColor: 'var(--editor-header-accent)',
+      opacity: 0.12,
+      borderRadius: '6px',
+      transition: 'all 100ms ease',
+      pointerEvents: 'none',
+      zIndex: 50,
+    };
+
+    switch (dropZone) {
+      case 'left':
+        return {
+          ...base,
+          top: '4px',
+          left: '4px',
+          bottom: '4px',
+          width: '48%',
+        };
+      case 'right':
+        return {
+          ...base,
+          top: '4px',
+          right: '4px',
+          bottom: '4px',
+          width: '48%',
+        };
+      case 'top':
+        return {
+          ...base,
+          top: '4px',
+          left: '4px',
+          right: '4px',
+          height: '48%',
+        };
+      case 'bottom':
+        return {
+          ...base,
+          bottom: '4px',
+          left: '4px',
+          right: '4px',
+          height: '48%',
+        };
+      default:
+        return undefined;
+    }
+  };
+
+  const overlayStyle = dropOverlayStyle();
+
   return (
     <div
+      ref={paneRef}
       className="flex flex-col h-full w-full"
       data-testid="editor-pane"
       onMouseDown={handlePaneClick}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
       style={{
-        borderTop: isActivePane
-          ? '2px solid var(--editor-header-accent)'
-          : '2px solid transparent',
+        position: 'relative',
+        outline:
+          isActivePane && hasMultiplePanes
+            ? '1px solid color-mix(in srgb, var(--editor-header-accent) 40%, transparent)'
+            : 'none',
+        outlineOffset: '-1px',
       }}
     >
+      {overlayStyle && <div style={overlayStyle} />}
       <EditorTabs paneId={paneId} />
       {activeFileId === 'welcome' ? (
         <WelcomePage />

--- a/src/components/layout/editor/EditorPane.tsx
+++ b/src/components/layout/editor/EditorPane.tsx
@@ -56,11 +56,13 @@ export function EditorPane({ paneId }: EditorPaneProps) {
     if (!hasTab && !hasFile) return;
 
     e.preventDefault();
+    e.stopPropagation();
     e.dataTransfer.dropEffect = 'move';
     setDropZone(getDropZone(e));
   };
 
   const handleDragLeave = (e: React.DragEvent) => {
+    e.stopPropagation();
     // Only reset if we're actually leaving the pane (not entering a child)
     if (paneRef.current && !paneRef.current.contains(e.relatedTarget as Node)) {
       setDropZone(null);
@@ -69,6 +71,7 @@ export function EditorPane({ paneId }: EditorPaneProps) {
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     const zone = getDropZone(e);
     setDropZone(null);
 

--- a/src/components/layout/editor/EditorStatusBar.tsx
+++ b/src/components/layout/editor/EditorStatusBar.tsx
@@ -1,18 +1,24 @@
 import { EditorStatusBarItem } from './EditorStatusBarItem';
 import { useAppStore } from '../../../store/useAppStore';
+import { useSplitStore } from '../../../store/useSplitStore';
 
 interface EditorStatusBarProps {
+  paneId: string;
   isPreview: boolean;
   cursorLine?: number;
   cursorCol?: number;
 }
 
 export function EditorStatusBar({
+  paneId,
   isPreview,
   cursorLine,
   cursorCol,
 }: EditorStatusBarProps) {
-  const { activeFileContent, isAutoSave } = useAppStore();
+  const activeFileContent = useSplitStore(
+    (state) => state.panes[paneId]?.activeFileContent ?? ''
+  );
+  const { isAutoSave } = useAppStore();
 
   // Calculate lines and words
   const lines = activeFileContent ? activeFileContent.split('\n').length : 0;

--- a/src/components/layout/editor/EditorTabs.tsx
+++ b/src/components/layout/editor/EditorTabs.tsx
@@ -13,6 +13,7 @@ import { useAppStore } from '../../../store/useAppStore';
 import { useSplitStore } from '../../../store/useSplitStore';
 import { showTabContextMenu } from '../../../util/contextMenu';
 import { isMac } from '../../../util/tauri';
+import { setCurrentDrag } from '../../../util/dragContext';
 
 interface EditorTabsProps {
   paneId: string;
@@ -32,6 +33,15 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
   const hasMultiplePanes = useSplitStore(
     (state) => state.rootNode.type === 'branch'
   );
+
+  // Check if this is the leftmost pane (first in tree traversal order)
+  const isLeftmostPane = useSplitStore((state) => {
+    const getFirstPaneId = (node: typeof state.rootNode): string => {
+      if (node.type === 'leaf') return node.paneId;
+      return getFirstPaneId(node.children[0]);
+    };
+    return getFirstPaneId(state.rootNode) === paneId;
+  });
 
   // Global state from app store
   const {
@@ -80,7 +90,7 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
         }}
       >
         {/* macOS traffic lights spacer when sidebar is collapsed */}
-        {isMac() && (
+        {isMac() && isLeftmostPane && (
           <div
             data-tauri-drag-region
             className="shrink-0 h-full transition-[width] duration-200 ease-in-out"
@@ -114,7 +124,13 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
                     JSON.stringify({ fileId, sourcePaneId: paneId })
                   );
                   e.dataTransfer.effectAllowed = 'move';
+                  setCurrentDrag({
+                    fileId,
+                    sourcePaneId: paneId,
+                    isFolder: false,
+                  });
                 }}
+                onDragEnd={() => setCurrentDrag(null)}
                 onClick={() => selectFile(fileId)}
                 onContextMenu={(e) => {
                   e.preventDefault();

--- a/src/components/layout/editor/EditorTabs.tsx
+++ b/src/components/layout/editor/EditorTabs.tsx
@@ -3,7 +3,6 @@ import {
   Plus,
   FileText,
   PanelLeft,
-  Gift,
   Maximize2,
   Minimize2,
   Info,
@@ -95,11 +94,9 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
             const file = findFile(fileId);
             const isActive = activeFileId === fileId;
             const isBlankTab = fileId.startsWith('new-tab-');
-            const isWelcomeTab = fileId === 'welcome';
 
             let tabName = '';
-            if (isWelcomeTab) tabName = 'Welcome';
-            else if (isBlankTab) tabName = 'Untitled';
+            if (isBlankTab) tabName = 'Untitled';
             else if (fileId === 'cinder-settings') tabName = 'Settings';
             else if (fileId === 'cinder-info') tabName = 'About';
             else if (fileId === 'cinder-trash') tabName = 'Trash';
@@ -149,20 +146,8 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
                     : 'var(--text-secondary)',
                 }}
               >
-                {!isWelcomeTab && !fileId.startsWith('cinder-') && (
+                {!fileId.startsWith('cinder-') && (
                   <FileText
-                    size={14}
-                    className={`mr-2 shrink-0 transition-opacity ${isActive ? 'opacity-100' : 'opacity-40'}`}
-                    style={{
-                      color: isActive
-                        ? 'var(--editor-header-accent)'
-                        : 'inherit',
-                    }}
-                  />
-                )}
-
-                {isWelcomeTab && (
-                  <Gift
                     size={14}
                     className={`mr-2 shrink-0 transition-opacity ${isActive ? 'opacity-100' : 'opacity-40'}`}
                     style={{

--- a/src/components/layout/editor/EditorTabs.tsx
+++ b/src/components/layout/editor/EditorTabs.tsx
@@ -11,20 +11,31 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useAppStore } from '../../../store/useAppStore';
+import { useSplitStore } from '../../../store/useSplitStore';
 import { showTabContextMenu } from '../../../util/contextMenu';
 import { isMac } from '../../../util/tauri';
 
-export function EditorTabs() {
+interface EditorTabsProps {
+  paneId: string;
+}
+
+export function EditorTabs({ paneId }: EditorTabsProps) {
+  // Pane-scoped state from split store
+  const openFiles = useSplitStore(
+    (state) => state.panes[paneId]?.openFiles ?? []
+  );
+  const activeFileId = useSplitStore(
+    (state) => state.panes[paneId]?.activeFileId ?? null
+  );
+  const hasMultiplePanes = useSplitStore(
+    (state) => state.rootNode.type === 'branch'
+  );
+
+  // Global state from app store
   const {
-    openFiles,
-    activeFileId,
-    selectFile,
-    closeFile,
     findFile,
-    createNewTab,
     toggleExplorerCollapsed,
     isExplorerCollapsed,
-    openFileInNewTab,
     setRenamingFileId,
     deleteFile,
     deleteFolder,
@@ -32,10 +43,28 @@ export function EditorTabs() {
     createFile,
     createFileInFolder,
     createFolder,
-    closeOtherFiles,
-    closeAllFiles,
     togglePin,
   } = useAppStore();
+
+  // Pane-scoped action wrappers
+  const selectFile = (fileId: string) => {
+    useSplitStore.getState().paneSelectFile(paneId, fileId);
+  };
+  const closeFile = (fileId: string) => {
+    useSplitStore.getState().paneCloseFile(paneId, fileId);
+  };
+  const createNewTab = () => {
+    useSplitStore.getState().paneCreateNewTab(paneId);
+  };
+  const openFileInNewTab = (fileId: string) => {
+    useSplitStore.getState().paneOpenFileInNewTab(paneId, fileId);
+  };
+  const closeOtherFiles = (fileId: string) => {
+    useSplitStore.getState().paneCloseOtherFiles(paneId, fileId);
+  };
+  const closeAllFiles = () => {
+    useSplitStore.getState().paneCloseAllFiles(paneId);
+  };
 
   return (
     <>
@@ -173,12 +202,7 @@ export function EditorTabs() {
         </div>
 
         {/* Right Side Controls - Fixed */}
-        <div
-          className="flex items-center h-full px-2 gap-1 border-l shrink-0 z-10"
-          style={{
-            borderColor: 'var(--border-primary)',
-          }}
-        >
+        <div className="flex items-center h-full px-2 gap-1 shrink-0 z-10">
           {/* New Tab Button */}
           <button
             onClick={createNewTab}
@@ -189,6 +213,19 @@ export function EditorTabs() {
           >
             <Plus size={18} />
           </button>
+
+          {/* Close Pane (only when multiple panes exist) */}
+          {hasMultiplePanes && (
+            <button
+              onClick={() => useSplitStore.getState().closePane(paneId)}
+              className="flex items-center justify-center w-[32px] h-[32px] rounded-md transition-colors hover:bg-[var(--bg-hover)]"
+              style={{ color: 'var(--text-tertiary)' }}
+              title="Close Pane"
+              data-testid="close-pane-button"
+            >
+              <X size={16} />
+            </button>
+          )}
 
           {/* Sidebar Toggle */}
           <button

--- a/src/components/layout/editor/EditorTabs.tsx
+++ b/src/components/layout/editor/EditorTabs.tsx
@@ -24,6 +24,9 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
   const openFiles = useSplitStore(
     (state) => state.panes[paneId]?.openFiles ?? []
   );
+  const isMaximized = useSplitStore(
+    (state) => state.maximizedPaneId === paneId
+  );
   const activeFileId = useSplitStore(
     (state) => state.panes[paneId]?.activeFileId ?? null
   );
@@ -246,26 +249,24 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
             <PanelLeft size={16} />
           </button>
 
-          {/* Fullscreen Toggle */}
-          <button
-            onClick={toggleExplorerCollapsed}
-            className="flex items-center justify-center w-[32px] h-[32px] rounded-md transition-colors hover:bg-[var(--bg-hover)]"
-            style={{
-              color: isExplorerCollapsed
-                ? 'var(--editor-header-accent)'
-                : 'var(--text-tertiary)',
-            }}
-            title={
-              isExplorerCollapsed ? 'Exit Fullscreen' : 'Fullscreen Editor'
-            }
-            data-testid="fullscreen-button"
-          >
-            {isExplorerCollapsed ? (
-              <Minimize2 size={16} />
-            ) : (
-              <Maximize2 size={16} />
-            )}
-          </button>
+          {/* Fullscreen Toggle (only when multiple panes exist) */}
+          {hasMultiplePanes && (
+            <button
+              onClick={() =>
+                useSplitStore.getState().toggleMaximizePane(paneId)
+              }
+              className="flex items-center justify-center w-[32px] h-[32px] rounded-md transition-colors hover:bg-[var(--bg-hover)]"
+              style={{
+                color: isMaximized
+                  ? 'var(--editor-header-accent)'
+                  : 'var(--text-tertiary)',
+              }}
+              title={isMaximized ? 'Restore Split' : 'Maximize Pane'}
+              data-testid="fullscreen-button"
+            >
+              {isMaximized ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+            </button>
+          )}
         </div>
       </div>
       <div

--- a/src/components/layout/editor/EditorTabs.tsx
+++ b/src/components/layout/editor/EditorTabs.tsx
@@ -107,6 +107,14 @@ export function EditorTabs({ paneId }: EditorTabsProps) {
                 key={fileId}
                 data-no-drag
                 data-testid="editor-tab"
+                draggable={true}
+                onDragStart={(e) => {
+                  e.dataTransfer.setData(
+                    'application/cinder-tab',
+                    JSON.stringify({ fileId, sourcePaneId: paneId })
+                  );
+                  e.dataTransfer.effectAllowed = 'move';
+                }}
                 onClick={() => selectFile(fileId)}
                 onContextMenu={(e) => {
                   e.preventDefault();

--- a/src/components/layout/editor/SplitContainer.tsx
+++ b/src/components/layout/editor/SplitContainer.tsx
@@ -17,6 +17,7 @@ export function SplitContainer({ node, path = [] }: SplitContainerProps) {
   return (
     <div
       className="split-container"
+      data-testid="split-container"
       style={{
         display: 'flex',
         flexDirection: isHorizontal ? 'row' : 'column',
@@ -67,6 +68,7 @@ function SplitChild({
     <>
       <div
         className="split-pane-wrapper"
+        data-testid="split-pane-wrapper"
         style={{
           flex: flex,
           minWidth: isHorizontal ? '200px' : undefined,

--- a/src/components/layout/editor/SplitContainer.tsx
+++ b/src/components/layout/editor/SplitContainer.tsx
@@ -1,4 +1,4 @@
-import type { SplitNode } from '../../../store/useSplitStore';
+import { useSplitStore, type SplitNode } from '../../../store/useSplitStore';
 import { EditorPane } from './EditorPane';
 import { SplitResizeHandle } from './SplitResizeHandle';
 
@@ -61,6 +61,7 @@ function SplitChild({
 }: SplitChildProps) {
   const isHorizontal = axis === 'horizontal';
   const childPath = [...parentPath, index];
+  const isResizing = useSplitStore((state) => state.isResizing);
 
   return (
     <>
@@ -72,6 +73,9 @@ function SplitChild({
           minHeight: !isHorizontal ? '150px' : undefined,
           overflow: 'hidden',
           position: 'relative',
+          transition: isResizing
+            ? 'none'
+            : 'flex 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
         }}
       >
         <SplitContainer node={child} path={childPath} />

--- a/src/components/layout/editor/SplitContainer.tsx
+++ b/src/components/layout/editor/SplitContainer.tsx
@@ -1,0 +1,95 @@
+import type { SplitNode } from '../../../store/useSplitStore';
+import { EditorPane } from './EditorPane';
+import { SplitResizeHandle } from './SplitResizeHandle';
+
+interface SplitContainerProps {
+  node: SplitNode;
+  path?: number[];
+}
+
+export function SplitContainer({ node, path = [] }: SplitContainerProps) {
+  if (node.type === 'leaf') {
+    return <EditorPane paneId={node.paneId} />;
+  }
+
+  const isHorizontal = node.axis === 'horizontal';
+
+  return (
+    <div
+      className="split-container"
+      style={{
+        display: 'flex',
+        flexDirection: isHorizontal ? 'row' : 'column',
+        width: '100%',
+        height: '100%',
+        minWidth: 0,
+        minHeight: 0,
+      }}
+    >
+      {node.children.map((child, i) => (
+        <SplitChild
+          key={getChildKey(child)}
+          child={child}
+          flex={node.flexes[i]}
+          index={i}
+          total={node.children.length}
+          axis={node.axis}
+          parentPath={path}
+        />
+      ))}
+    </div>
+  );
+}
+
+// Separate component to avoid key issues with fragments
+interface SplitChildProps {
+  child: SplitNode;
+  flex: number;
+  index: number;
+  total: number;
+  axis: 'horizontal' | 'vertical';
+  parentPath: number[];
+}
+
+function SplitChild({
+  child,
+  flex,
+  index,
+  total,
+  axis,
+  parentPath,
+}: SplitChildProps) {
+  const isHorizontal = axis === 'horizontal';
+  const childPath = [...parentPath, index];
+
+  return (
+    <>
+      <div
+        className="split-pane-wrapper"
+        style={{
+          flex: flex,
+          minWidth: isHorizontal ? '200px' : undefined,
+          minHeight: !isHorizontal ? '150px' : undefined,
+          overflow: 'hidden',
+          position: 'relative',
+        }}
+      >
+        <SplitContainer node={child} path={childPath} />
+      </div>
+      {index < total - 1 && (
+        <SplitResizeHandle
+          axis={axis}
+          branchPath={parentPath}
+          childIndex={index}
+        />
+      )}
+    </>
+  );
+}
+
+/** Get a stable key for a child node */
+function getChildKey(node: SplitNode): string {
+  if (node.type === 'leaf') return node.paneId;
+  // For branches, use a composite of child keys
+  return `branch-${node.children.map(getChildKey).join('-')}`;
+}

--- a/src/components/layout/editor/SplitResizeHandle.tsx
+++ b/src/components/layout/editor/SplitResizeHandle.tsx
@@ -20,6 +20,7 @@ export function SplitResizeHandle({
     (e: React.MouseEvent) => {
       e.preventDefault();
       setIsDragging(true);
+      useSplitStore.getState().setIsResizing(true);
 
       // Track last position for incremental deltas (not absolute from start)
       let lastPos = axis === 'horizontal' ? e.clientX : e.clientY;
@@ -52,6 +53,7 @@ export function SplitResizeHandle({
 
       const handleMouseUp = () => {
         setIsDragging(false);
+        useSplitStore.getState().setIsResizing(false);
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
         window.removeEventListener('mousemove', handleMouseMove);

--- a/src/components/layout/editor/SplitResizeHandle.tsx
+++ b/src/components/layout/editor/SplitResizeHandle.tsx
@@ -76,6 +76,7 @@ export function SplitResizeHandle({
     <div
       ref={containerRef}
       className="split-resize-handle"
+      data-testid="split-resize-handle"
       style={{
         position: 'relative',
         flexShrink: 0,

--- a/src/components/layout/editor/SplitResizeHandle.tsx
+++ b/src/components/layout/editor/SplitResizeHandle.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useRef, useState } from 'react';
+import { useSplitStore } from '../../../store/useSplitStore';
+
+interface SplitResizeHandleProps {
+  axis: 'horizontal' | 'vertical';
+  branchPath: number[];
+  childIndex: number;
+}
+
+export function SplitResizeHandle({
+  axis,
+  branchPath,
+  childIndex,
+}: SplitResizeHandleProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsDragging(true);
+
+      // Track last position for incremental deltas (not absolute from start)
+      let lastPos = axis === 'horizontal' ? e.clientX : e.clientY;
+
+      // Get the parent container to calculate relative positions
+      const handle = containerRef.current;
+      if (!handle) return;
+      const parent = handle.parentElement;
+      if (!parent) return;
+
+      const parentRect = parent.getBoundingClientRect();
+      const parentSize =
+        axis === 'horizontal' ? parentRect.width : parentRect.height;
+
+      document.body.style.cursor =
+        axis === 'horizontal' ? 'col-resize' : 'row-resize';
+      document.body.style.userSelect = 'none';
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const currentPos =
+          axis === 'horizontal' ? moveEvent.clientX : moveEvent.clientY;
+        const deltaPx = currentPos - lastPos;
+        lastPos = currentPos;
+        const deltaRatio = deltaPx / parentSize;
+
+        useSplitStore
+          .getState()
+          .setSplitRatio(branchPath, childIndex, deltaRatio);
+      };
+
+      const handleMouseUp = () => {
+        setIsDragging(false);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [axis, branchPath, childIndex]
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    useSplitStore.getState().resetFlexes(branchPath);
+  }, [branchPath]);
+
+  const isActive = isHovered || isDragging;
+
+  return (
+    <div
+      ref={containerRef}
+      className="split-resize-handle"
+      style={{
+        position: 'relative',
+        flexShrink: 0,
+        [axis === 'horizontal' ? 'width' : 'height']: '4px',
+        [axis === 'horizontal' ? 'height' : 'width']: '100%',
+        cursor: axis === 'horizontal' ? 'col-resize' : 'row-resize',
+        zIndex: 10,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {/* Visible line */}
+      <div
+        style={{
+          position: 'absolute',
+          [axis === 'horizontal' ? 'width' : 'height']: isActive
+            ? '2px'
+            : '1px',
+          [axis === 'horizontal' ? 'height' : 'width']: '100%',
+          backgroundColor: isActive
+            ? 'var(--editor-header-accent)'
+            : 'var(--separator)',
+          transition:
+            'background-color 150ms ease, width 150ms ease, height 150ms ease',
+          borderRadius: '1px',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/layout/explorer/FileTreeItem.tsx
+++ b/src/components/layout/explorer/FileTreeItem.tsx
@@ -6,6 +6,7 @@ import {
   showFileContextMenu,
   showFolderContextMenu,
 } from '../../../util/contextMenu';
+import { setCurrentDrag } from '../../../util/dragContext';
 
 function formatDate(epochSeconds: number): string {
   const date = new Date(epochSeconds * 1000);
@@ -141,6 +142,11 @@ export function FileTreeItem({
     e.stopPropagation();
     e.dataTransfer.setData('text/plain', node.id);
     e.dataTransfer.effectAllowed = 'move';
+    setCurrentDrag({
+      fileId: node.id,
+      sourcePaneId: null,
+      isFolder: node.type === 'folder',
+    });
     // Visual feedback
     if (e.currentTarget instanceof HTMLElement) {
       e.currentTarget.style.opacity = '0.4';
@@ -152,6 +158,7 @@ export function FileTreeItem({
       e.currentTarget.style.opacity = '1';
     }
     setDragState((prev) => ({ ...prev, isOver: false }));
+    setCurrentDrag(null);
   };
 
   const handleDragOver = (e: React.DragEvent) => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -8,14 +8,11 @@
 
 import { useEffect } from 'react';
 import { useAppStore } from '../store/useAppStore';
+import { useSplitStore } from '../store/useSplitStore';
 
 export function useKeyboardShortcuts() {
   const {
-    activeFileId,
-    activeFileContent,
-    updateFileContent,
     createFile,
-    closeFile,
     toggleExplorerCollapsed,
     createFolder,
     isSearchOpen,
@@ -32,13 +29,21 @@ export function useKeyboardShortcuts() {
         // Cmd+S -- Force save (prevent browser save dialog)
         case 's': {
           e.preventDefault();
+          const splitState = useSplitStore.getState();
+          const pane = splitState.panes[splitState.activePaneId];
+          const activeFileId = pane?.activeFileId;
+          const activeFileContent = pane?.activeFileContent ?? '';
           if (
             activeFileId &&
             !activeFileId.startsWith('cinder-') &&
             activeFileId !== 'welcome'
           ) {
             // Trigger a save by re-writing current content
-            updateFileContent(activeFileId, activeFileContent);
+            splitState.paneUpdateFileContent(
+              splitState.activePaneId,
+              activeFileId,
+              activeFileContent
+            );
           }
           break;
         }
@@ -56,11 +61,16 @@ export function useKeyboardShortcuts() {
           break;
         }
 
-        // Cmd+W -- Close current tab
+        // Cmd+W -- Close current tab in active pane
         case 'w': {
           e.preventDefault();
-          if (activeFileId) {
-            closeFile(activeFileId);
+          const splitState = useSplitStore.getState();
+          const pane = splitState.panes[splitState.activePaneId];
+          if (pane?.activeFileId) {
+            splitState.paneCloseFile(
+              splitState.activePaneId,
+              pane.activeFileId
+            );
           }
           break;
         }
@@ -81,17 +91,26 @@ export function useKeyboardShortcuts() {
           // Plain Cmd+F is left to CodeMirror's built-in find/replace
           break;
         }
+
+        // Cmd+\ -- Split right (horizontal)
+        case '\\': {
+          e.preventDefault();
+          const splitState = useSplitStore.getState();
+          if (e.shiftKey) {
+            // Cmd+Shift+\ -- Split down (vertical)
+            splitState.splitPane(splitState.activePaneId, 'vertical');
+          } else {
+            splitState.splitPane(splitState.activePaneId, 'horizontal');
+          }
+          break;
+        }
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [
-    activeFileId,
-    activeFileContent,
-    updateFileContent,
     createFile,
-    closeFile,
     toggleExplorerCollapsed,
     createFolder,
     isSearchOpen,

--- a/src/store/storeBridge.ts
+++ b/src/store/storeBridge.ts
@@ -1,0 +1,27 @@
+/**
+ * Bridge module to break the circular dependency between useAppStore and useSplitStore.
+ *
+ * Both stores need to call each other's methods. Since ES modules don't allow
+ * circular imports at the top level, this module provides a lazy accessor pattern.
+ * Each store registers itself here at creation time, and the other store accesses
+ * it through the getter.
+ */
+
+import type { StoreApi } from 'zustand';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let splitStoreRef: StoreApi<any> | null = null;
+
+export function registerSplitStore(store: StoreApi<unknown>): void {
+  splitStoreRef = store;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getSplitStore(): StoreApi<any> {
+  if (!splitStoreRef) {
+    throw new Error(
+      'SplitStore not yet registered. This is a startup race condition.'
+    );
+  }
+  return splitStoreRef;
+}

--- a/src/store/storeBridge.ts
+++ b/src/store/storeBridge.ts
@@ -25,3 +25,12 @@ export function getSplitStore(): StoreApi<any> {
   }
   return splitStoreRef;
 }
+
+/**
+ * Non-throwing variant for use in deferred subscriptions / test environments.
+ * Returns null if the split store hasn't been registered yet.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function tryGetSplitStore(): StoreApi<any> | null {
+  return splitStoreRef;
+}

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type { FileNode } from '../types/fileSystem';
 import type { RecentWorkspace } from '../types/recentWorkspace';
 import { joinPath, basename, dirname } from '../utils/pathUtils';
+import { getSplitStore } from './storeBridge';
 
 export interface SearchResult {
   file_path: string;
@@ -199,142 +200,15 @@ export const useAppStore = create<AppState>()(
       },
 
       selectFile: (fileId: string) => {
-        // Handle blank tabs
-        if (fileId.startsWith('new-tab-')) {
-          set((state) => {
-            // If currently on welcome page, replace it
-            if (state.activeFileId === 'welcome') {
-              return {
-                activeFileId: fileId,
-                activeFileContent: '',
-                openFiles: [fileId], // Replace welcome entirely
-              };
-            }
-            return {
-              activeFileId: fileId,
-              activeFileContent: '',
-            };
-          });
-          return;
-        }
-
-        // Handle System Tabs
-        if (fileId.startsWith('cinder-')) {
-          set({ activeFileId: fileId, activeFileContent: '' });
-          return;
-        }
-
-        const file = get().findFile(fileId);
-        if (file && file.type === 'file') {
-          const { openFiles, activeFileId } = get();
-          const filePath = file.path;
-
-          // Helper to update state with content
-          const updateWithContent = (content: string) => {
-            const currentState = get();
-            const currentActiveId = currentState.activeFileId;
-
-            // If currently on a blank tab OR welcome tab, replace it
-            if (
-              currentActiveId &&
-              (currentActiveId.startsWith('new-tab-') ||
-                currentActiveId === 'welcome')
-            ) {
-              const newOpenFiles = currentState.openFiles.map((id) =>
-                id === currentActiveId ? fileId : id
-              );
-              set({
-                activeFileId: fileId,
-                activeFileContent: content,
-                openFiles: newOpenFiles,
-              });
-            } else {
-              // Otherwise, open in new tab if not already open
-              const needsToOpen = !currentState.openFiles.includes(fileId);
-              set({
-                activeFileId: fileId,
-                activeFileContent: content,
-                openFiles: needsToOpen
-                  ? [...currentState.openFiles, fileId]
-                  : currentState.openFiles,
-              });
-            }
-          };
-
-          // If file has a path, read from disk
-          if (filePath) {
-            // Set as active immediately with loading state
-            if (
-              activeFileId &&
-              (activeFileId.startsWith('new-tab-') ||
-                activeFileId === 'welcome')
-            ) {
-              const newOpenFiles = openFiles.map((id) =>
-                id === activeFileId ? fileId : id
-              );
-              set({
-                activeFileId: fileId,
-                openFiles: newOpenFiles,
-                activeFileContent: '',
-              });
-            } else {
-              const needsToOpen = !openFiles.includes(fileId);
-              set({
-                activeFileId: fileId,
-                openFiles: needsToOpen ? [...openFiles, fileId] : openFiles,
-                activeFileContent: '',
-              });
-            }
-
-            // Read content from disk
-            invoke<string>('read_note', { path: filePath })
-              .then((content) => {
-                // Only update if this file is still active
-                if (get().activeFileId === fileId) {
-                  set({ activeFileContent: content });
-                }
-              })
-              .catch((err) => {
-                console.error('Failed to read file:', err);
-                set({ activeFileContent: `Error loading file: ${err}` });
-              });
-          } else {
-            // Fallback to in-memory content
-            updateWithContent(file.content || '');
-          }
-        }
+        // Delegate to split store - opens file in the active pane
+        const splitState = getSplitStore().getState();
+        splitState.paneSelectFile(splitState.activePaneId, fileId);
       },
 
       openSystemTab: (tabId: string) => {
-        const { openFiles, activeFileId } = get();
-
-        // If already open, just select it
-        if (openFiles.includes(tabId)) {
-          set({ activeFileId: tabId, activeFileContent: '' });
-          return;
-        }
-
-        // If currently on welcome/blank, replace it
-        if (
-          activeFileId &&
-          (activeFileId === 'welcome' || activeFileId.startsWith('new-tab-'))
-        ) {
-          const newOpenFiles = openFiles.map((id) =>
-            id === activeFileId ? tabId : id
-          );
-          set({
-            activeFileId: tabId,
-            openFiles: newOpenFiles,
-            activeFileContent: '',
-          });
-        } else {
-          // Append
-          set({
-            activeFileId: tabId,
-            openFiles: [...openFiles, tabId],
-            activeFileContent: '',
-          });
-        }
+        // Delegate to split store
+        const splitState = getSplitStore().getState();
+        splitState.paneOpenSystemTab(splitState.activePaneId, tabId);
       },
 
       toggleAutoSave: () => set((state) => ({ isAutoSave: !state.isAutoSave })),
@@ -350,71 +224,15 @@ export const useAppStore = create<AppState>()(
         }),
 
       openFileInNewTab: (fileId: string) => {
-        const file = get().findFile(fileId);
-        if (file && file.type === 'file') {
-          const { openFiles, activeFileId } = get();
-          const filePath = file.path;
-
-          // Set as active immediately
-          if (
-            activeFileId &&
-            (activeFileId.startsWith('new-tab-') || activeFileId === 'welcome')
-          ) {
-            const newOpenFiles = openFiles.map((id) =>
-              id === activeFileId ? fileId : id
-            );
-            set({
-              activeFileId: fileId,
-              openFiles: newOpenFiles,
-              activeFileContent: '',
-            });
-          } else {
-            const needsToOpen = !openFiles.includes(fileId);
-            set({
-              activeFileId: fileId,
-              openFiles: needsToOpen ? [...openFiles, fileId] : openFiles,
-              activeFileContent: '',
-            });
-          }
-
-          // If file has a path, read from disk
-          if (filePath) {
-            invoke<string>('read_note', { path: filePath })
-              .then((content) => {
-                if (get().activeFileId === fileId) {
-                  set({ activeFileContent: content });
-                }
-              })
-              .catch((err) => {
-                console.error('Failed to read file:', err);
-                set({ activeFileContent: `Error loading file: ${err}` });
-              });
-          } else {
-            // Fallback to in-memory content
-            set({ activeFileContent: file.content || '' });
-          }
-        }
+        // Delegate to split store
+        const splitState = getSplitStore().getState();
+        splitState.paneOpenFileInNewTab(splitState.activePaneId, fileId);
       },
 
       closeFile: (fileId: string) => {
-        const { openFiles, activeFileId } = get();
-        const newOpenFiles = openFiles.filter((id) => id !== fileId);
-
-        if (activeFileId === fileId) {
-          const nextActive =
-            newOpenFiles.length > 0
-              ? newOpenFiles[newOpenFiles.length - 1]
-              : null;
-          if (nextActive) {
-            get().selectFile(nextActive);
-          } else {
-            set({ activeFileId: null, activeFileContent: '' });
-            // If we closed the last tab, we might want to show empty state or Welcome?
-            // For now, empty state is fine.
-          }
-        }
-
-        set({ openFiles: newOpenFiles });
+        // Delegate to split store
+        const splitState = getSplitStore().getState();
+        splitState.paneCloseFile(splitState.activePaneId, fileId);
       },
 
       updateFileContent: (fileId: string, content: string) => {
@@ -559,38 +377,16 @@ export const useAppStore = create<AppState>()(
       },
 
       createNewTab: () => {
-        set((state) => {
-          const newCounter = state.newTabCounter + 1;
-          const newTabId = `new-tab-${newCounter}`;
-
-          // If currently on welcome, replace it
-          if (state.activeFileId === 'welcome') {
-            return {
-              newTabCounter: newCounter,
-              activeFileId: newTabId,
-              openFiles: [newTabId],
-              activeFileContent: '',
-              renamingFileId: null, // Don't rename yet
-              renameSource: null,
-            };
-          }
-
-          return {
-            newTabCounter: newCounter,
-            activeFileId: newTabId,
-            openFiles: [...state.openFiles, newTabId],
-            activeFileContent: '',
-            renamingFileId: newTabId,
-            renameSource: 'editor',
-          };
-        });
+        // Delegate to split store
+        const splitState = getSplitStore().getState();
+        splitState.paneCreateNewTab(splitState.activePaneId);
       },
 
       createFile: () => {
         // Creates file in tree immediately with rename mode active
         // Also creates it on disk immediately
         const state = get();
-        const { files, openFiles, workspacePath } = state;
+        const { files, workspacePath } = state;
 
         if (!workspacePath) {
           console.error('No workspace path set');
@@ -637,17 +433,17 @@ export const useAppStore = create<AppState>()(
 
         // Add to file tree at root level
         const newFiles = [...files, newFile];
-        const newOpenFiles = [...openFiles, newFileId];
 
         set({
           files: newFiles,
-          activeFileId: newFileId,
-          openFiles: newOpenFiles,
-          activeFileContent: '',
           renamingFileId: newFileId,
           pendingFileId: newFileId, // If cancelled, remove it
           renameSource: 'explorer',
         });
+
+        // Open in the active pane via split store
+        const splitState = getSplitStore().getState();
+        splitState.paneSelectFile(splitState.activePaneId, newFileId);
       },
 
       setRenamingFileId: (id, source) =>
@@ -780,6 +576,22 @@ export const useAppStore = create<AppState>()(
             renameSource: null,
             pendingFileId: null,
           });
+
+          // Sync the new file ID to the active pane in split store
+          const splitState = getSplitStore().getState();
+          const activePaneId = splitState.activePaneId;
+          const pane = splitState.panes[activePaneId];
+          if (pane && pane.activeFileId === id) {
+            const updatedPanes = { ...splitState.panes };
+            updatedPanes[activePaneId] = {
+              ...pane,
+              activeFileId: newFileId,
+              openFiles: pane.openFiles.map((fid: string) =>
+                fid === id ? newFileId : fid
+              ),
+            };
+            getSplitStore().setState({ panes: updatedPanes });
+          }
           return;
         }
 
@@ -1035,9 +847,50 @@ export const useAppStore = create<AppState>()(
             nextActiveId === state.activeFileId ? state.activeFileContent : '',
         });
 
-        // If there's a next active file, select it to load content
-        if (nextActiveId && nextActiveId !== state.activeFileId) {
-          get().selectFile(nextActiveId);
+        // Close the deleted file from all panes in the split store
+        const splitState = getSplitStore().getState();
+        const updatedPanes = { ...splitState.panes };
+        let needsUpdate = false;
+        for (const [paneId, pane] of Object.entries(splitState.panes)) {
+          const paneState = pane as {
+            activeFileId: string | null;
+            openFiles: string[];
+            activeFileContent: string;
+          };
+          if (paneState.openFiles.includes(fileId)) {
+            needsUpdate = true;
+            const newPaneOpenFiles = paneState.openFiles.filter(
+              (id: string) => id !== fileId
+            );
+            if (paneState.activeFileId === fileId) {
+              const nextPaneActive =
+                newPaneOpenFiles.length > 0
+                  ? newPaneOpenFiles[newPaneOpenFiles.length - 1]
+                  : null;
+              updatedPanes[paneId] = {
+                ...paneState,
+                openFiles: newPaneOpenFiles,
+                activeFileId: nextPaneActive,
+                activeFileContent: '',
+              };
+              // Load content for next file
+              if (nextPaneActive) {
+                setTimeout(() => {
+                  getSplitStore()
+                    .getState()
+                    .paneSelectFile(paneId, nextPaneActive);
+                }, 0);
+              }
+            } else {
+              updatedPanes[paneId] = {
+                ...paneState,
+                openFiles: newPaneOpenFiles,
+              };
+            }
+          }
+        }
+        if (needsUpdate) {
+          getSplitStore().setState({ panes: updatedPanes });
         }
       },
 
@@ -1182,7 +1035,7 @@ export const useAppStore = create<AppState>()(
 
       createFileInFolder: (folderId: string) => {
         const state = get();
-        const { files, openFiles, workspacePath } = state;
+        const { files, workspacePath } = state;
         const folder = state.findFile(folderId);
 
         if (!workspacePath || !folder || !folder.path) {
@@ -1244,14 +1097,15 @@ export const useAppStore = create<AppState>()(
 
         set({
           files: addToFolder(files),
-          activeFileId: newFileId,
-          openFiles: [...openFiles, newFileId],
-          activeFileContent: '',
           renamingFileId: newFileId,
           pendingFileId: newFileId,
           renameSource: 'explorer',
           expandedFolderIds: newExpandedFolderIds,
         });
+
+        // Open in the active pane via split store
+        const splitState = getSplitStore().getState();
+        splitState.paneSelectFile(splitState.activePaneId, newFileId);
       },
 
       createFolder: (parentFolderId?: string | null) => {
@@ -1341,24 +1195,15 @@ export const useAppStore = create<AppState>()(
       },
 
       closeOtherFiles: (fileId: string) => {
-        const state = get();
-        set({
-          openFiles: state.openFiles.includes(fileId) ? [fileId] : [],
-          activeFileId: state.openFiles.includes(fileId) ? fileId : null,
-          activeFileContent:
-            state.activeFileId === fileId ? state.activeFileContent : '',
-        });
-        if (state.activeFileId !== fileId && state.openFiles.includes(fileId)) {
-          get().selectFile(fileId);
-        }
+        // Delegate to split store
+        const splitState = getSplitStore().getState();
+        splitState.paneCloseOtherFiles(splitState.activePaneId, fileId);
       },
 
       closeAllFiles: () => {
-        set({
-          openFiles: [],
-          activeFileId: null,
-          activeFileContent: '',
-        });
+        // Delegate to split store
+        const splitState = getSplitStore().getState();
+        splitState.paneCloseAllFiles(splitState.activePaneId);
       },
     }),
     {
@@ -1371,3 +1216,22 @@ export const useAppStore = create<AppState>()(
     }
   )
 );
+
+// ─── Sync activeFileId from useSplitStore for backward compatibility ────────
+// Components like FileTreeItem read activeFileId from useAppStore to highlight
+// the active file in the sidebar. This subscription keeps it in sync.
+setTimeout(() => {
+  getSplitStore().subscribe(
+    (state: {
+      activePaneId: string;
+      panes: Record<string, { activeFileId: string | null }>;
+    }) => {
+      const pane = state.panes[state.activePaneId];
+      const splitActiveFileId = pane?.activeFileId ?? null;
+      const appActiveFileId = useAppStore.getState().activeFileId;
+      if (splitActiveFileId !== appActiveFileId) {
+        useAppStore.setState({ activeFileId: splitActiveFileId });
+      }
+    }
+  );
+}, 0);

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -4,7 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type { FileNode } from '../types/fileSystem';
 import type { RecentWorkspace } from '../types/recentWorkspace';
 import { joinPath, basename, dirname } from '../utils/pathUtils';
-import { getSplitStore } from './storeBridge';
+import { getSplitStore, tryGetSplitStore } from './storeBridge';
 
 export interface SearchResult {
   file_path: string;
@@ -1221,7 +1221,9 @@ export const useAppStore = create<AppState>()(
 // Components like FileTreeItem read activeFileId from useAppStore to highlight
 // the active file in the sidebar. This subscription keeps it in sync.
 setTimeout(() => {
-  getSplitStore().subscribe(
+  const store = tryGetSplitStore();
+  if (!store) return;
+  store.subscribe(
     (state: {
       activePaneId: string;
       panes: Record<string, { activeFileId: string | null }>;

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -36,7 +36,7 @@ function createEmptyPane(): PaneState {
 }
 
 /** Collect all pane IDs in the tree */
-function collectPaneIds(node: SplitNode): string[] {
+export function collectPaneIds(node: SplitNode): string[] {
   if (node.type === 'leaf') return [node.paneId];
   return node.children.flatMap(collectPaneIds);
 }
@@ -99,7 +99,7 @@ function removePaneFromTree(node: SplitNode, paneId: string): SplitNode | null {
   return { ...node, children: newChildren, flexes: normalizedFlexes };
 }
 
-function getPaneDepth(root: SplitNode, paneId: string): number {
+export function getPaneDepth(root: SplitNode, paneId: string): number {
   const path = findPanePath(root, paneId);
   return path ? path.length : 0;
 }
@@ -246,8 +246,8 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     const pane = state.panes[paneId];
     if (!pane) return;
 
-    // Limit splitting to depth 2 (e.g. one horizontal, one vertical max)
-    if (getPaneDepth(state.rootNode, paneId) >= 2) return;
+    // Limit to 4 panes max (four quadrants)
+    if (collectPaneIds(state.rootNode).length >= 4) return;
 
     const newPaneId = generatePaneId();
     const newPane: PaneState = {
@@ -347,8 +347,8 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
         .catch(console.error);
     }
 
-    // Limit splitting to depth 2
-    if (getPaneDepth(state.rootNode, paneId) >= 2) {
+    // Limit to 4 panes max (four quadrants)
+    if (collectPaneIds(state.rootNode).length >= 4) {
       // If we can't split, just move/open the file in the target pane
       if (sourcePaneId) {
         get().paneCloseFile(sourcePaneId, fileId);

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -276,11 +276,11 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     const targetPane = state.panes[paneId];
     if (!targetPane) return;
 
-    // Check if target pane is empty (or only has welcome tab). If so, just open the file there.
+    // Check if target pane is empty. If so, just open the file there.
     if (
       targetPane.openFiles.length === 0 ||
-      (targetPane.openFiles.length === 1 &&
-        targetPane.openFiles[0] === 'welcome')
+      targetPane.activeFileId === 'welcome' ||
+      targetPane.activeFileId === null
     ) {
       if (sourcePaneId) {
         get().paneCloseFile(sourcePaneId, fileId);
@@ -487,7 +487,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     // Handle blank tabs
     if (fileId.startsWith('new-tab-')) {
       const newPanes = { ...state.panes };
-      if (pane.activeFileId === 'welcome') {
+      if (!pane.activeFileId) {
         newPanes[paneId] = {
           ...pane,
           activeFileId: fileId,
@@ -510,9 +510,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       const newPanes = { ...state.panes };
       const openFiles = pane.openFiles.includes(fileId)
         ? pane.openFiles
-        : pane.activeFileId &&
-            (pane.activeFileId === 'welcome' ||
-              pane.activeFileId.startsWith('new-tab-'))
+        : pane.activeFileId === null || fileId.startsWith('new-tab-')
           ? pane.openFiles.map((id) => (id === pane.activeFileId ? fileId : id))
           : [...pane.openFiles, fileId];
 
@@ -535,11 +533,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
 
     // Determine new openFiles
     let newOpenFiles: string[];
-    if (
-      pane.activeFileId &&
-      (pane.activeFileId.startsWith('new-tab-') ||
-        pane.activeFileId === 'welcome')
-    ) {
+    if (pane.activeFileId && pane.activeFileId.startsWith('new-tab-')) {
       // Replace the blank/welcome tab
       newOpenFiles = pane.openFiles.map((id) =>
         id === pane.activeFileId ? fileId : id
@@ -611,11 +605,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     const filePath = file.path;
 
     let newOpenFiles: string[];
-    if (
-      pane.activeFileId &&
-      (pane.activeFileId.startsWith('new-tab-') ||
-        pane.activeFileId === 'welcome')
-    ) {
+    if (pane.activeFileId && pane.activeFileId.startsWith('new-tab-')) {
       newOpenFiles = pane.openFiles.map((id) =>
         id === pane.activeFileId ? fileId : id
       );
@@ -669,11 +659,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     let newOpenFiles: string[];
     if (pane.openFiles.includes(tabId)) {
       newOpenFiles = pane.openFiles;
-    } else if (
-      pane.activeFileId &&
-      (pane.activeFileId === 'welcome' ||
-        pane.activeFileId.startsWith('new-tab-'))
-    ) {
+    } else if (!pane.activeFileId || pane.activeFileId.startsWith('new-tab-')) {
       newOpenFiles = pane.openFiles.map((id) =>
         id === pane.activeFileId ? tabId : id
       );
@@ -705,15 +691,15 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
         get().closePane(paneId);
         return;
       } else {
-        // If it's the last pane, just show welcome
+        // If it's the last pane, just show welcome screen (empty state)
         set({
           panes: {
             ...state.panes,
             [paneId]: {
               ...pane,
-              activeFileId: 'welcome',
+              activeFileId: null,
               activeFileContent: '',
-              openFiles: ['welcome'],
+              openFiles: [],
             },
           },
         });
@@ -788,7 +774,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
 
     const newPanes = { ...state.panes };
 
-    if (pane.activeFileId === 'welcome') {
+    if (!pane.activeFileId || pane.activeFileId === 'welcome') {
       newPanes[paneId] = {
         activeFileId: newTabId,
         openFiles: [newTabId],

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -282,16 +282,16 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       (targetPane.openFiles.length === 1 &&
         targetPane.openFiles[0] === 'welcome')
     ) {
-      if (sourcePaneId && sourcePaneId !== paneId) {
+      if (sourcePaneId) {
         get().paneCloseFile(sourcePaneId, fileId);
       }
       get().paneSelectFile(paneId, fileId);
       return;
     }
 
-    // First, close the file from the source pane (if different pane)
+    // First, close the file from the source pane (if it exists)
     const updatedPanes = { ...state.panes };
-    if (sourcePaneId && sourcePaneId !== paneId && updatedPanes[sourcePaneId]) {
+    if (sourcePaneId && updatedPanes[sourcePaneId]) {
       const srcPane = updatedPanes[sourcePaneId];
       const newOpenFiles = srcPane.openFiles.filter(
         (id: string) => id !== fileId
@@ -305,6 +305,10 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
           : srcPane.activeFileId,
         activeFileContent: wasActive ? '' : srcPane.activeFileContent,
       };
+
+      // If the source pane became empty and it's not the target pane,
+      // we might want to auto-close it. But since we are about to update the tree,
+      // let's do it after the state update to avoid conflicts.
     }
 
     // Create the new pane with the dropped file
@@ -337,7 +341,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     // Limit splitting to depth 2
     if (getPaneDepth(state.rootNode, paneId) >= 2) {
       // If we can't split, just move/open the file in the target pane
-      if (sourcePaneId && sourcePaneId !== paneId) {
+      if (sourcePaneId) {
         get().paneCloseFile(sourcePaneId, fileId);
       }
       get().paneSelectFile(paneId, fileId);
@@ -360,6 +364,14 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       activePaneId: newPaneId,
       maximizedPaneId: null, // Clear maximize on split
     });
+
+    // Cleanup empty source pane if needed
+    if (sourcePaneId && sourcePaneId !== newPaneId) {
+      const currentSourcePane = get().panes[sourcePaneId];
+      if (currentSourcePane && currentSourcePane.openFiles.length === 0) {
+        get().closePane(sourcePaneId);
+      }
+    }
   },
 
   closePane: (paneId) => {
@@ -685,6 +697,30 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     if (!pane) return;
 
     const newOpenFiles = pane.openFiles.filter((id) => id !== fileId);
+
+    // Auto-close pane if it becomes empty
+    if (newOpenFiles.length === 0) {
+      const allPanes = collectPaneIds(state.rootNode);
+      if (allPanes.length > 1) {
+        get().closePane(paneId);
+        return;
+      } else {
+        // If it's the last pane, just show welcome
+        set({
+          panes: {
+            ...state.panes,
+            [paneId]: {
+              ...pane,
+              activeFileId: 'welcome',
+              activeFileContent: '',
+              openFiles: ['welcome'],
+            },
+          },
+        });
+        return;
+      }
+    }
+
     const newPanes = { ...state.panes };
 
     if (pane.activeFileId === fileId) {

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -182,6 +182,7 @@ interface SplitStoreState {
   rootNode: SplitNode;
   panes: Record<string, PaneState>;
   activePaneId: string;
+  maximizedPaneId: string | null;
   newTabCounter: number;
 
   // Tree actions
@@ -195,6 +196,7 @@ interface SplitStoreState {
   ) => void;
   closePane: (paneId: string) => void;
   setActivePaneId: (paneId: string) => void;
+  toggleMaximizePane: (paneId: string) => void;
   setSplitRatio: (
     branchPath: number[],
     childIndex: number,
@@ -226,6 +228,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
   rootNode: { type: 'leaf', paneId: initialPaneId },
   panes: { [initialPaneId]: createEmptyPane() },
   activePaneId: initialPaneId,
+  maximizedPaneId: null,
   newTabCounter: 0,
 
   // ─── Tree Actions ───────────────────────────────────────────────────────
@@ -258,6 +261,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       rootNode: newRoot,
       panes: { ...state.panes, [newPaneId]: newPane },
       activePaneId: newPaneId,
+      maximizedPaneId: null, // Clear maximize on split
     });
   },
 
@@ -354,6 +358,7 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       rootNode: newRoot,
       panes: { ...updatedPanes, [newPaneId]: newPane },
       activePaneId: newPaneId,
+      maximizedPaneId: null, // Clear maximize on split
     });
   },
 
@@ -382,6 +387,8 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       rootNode: newRoot,
       panes: newPanes,
       activePaneId: newActivePaneId,
+      maximizedPaneId:
+        state.maximizedPaneId === paneId ? null : state.maximizedPaneId,
     });
   },
 
@@ -851,15 +858,23 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     }
   },
 
+  toggleMaximizePane: (paneId) => {
+    const { maximizedPaneId } = get();
+    set({ maximizedPaneId: maximizedPaneId === paneId ? null : paneId });
+  },
+
   // ─── Init/Reset ─────────────────────────────────────────────────────────
 
   resetToSinglePane: () => {
-    const newPaneId = generatePaneId();
+    const state = get();
+    // Find the currently active pane to preserve it
+    const activeId = state.activePaneId;
+    const activePane = state.panes[activeId];
+
     set({
-      rootNode: { type: 'leaf', paneId: newPaneId },
-      panes: { [newPaneId]: createEmptyPane() },
-      activePaneId: newPaneId,
-      newTabCounter: 0,
+      rootNode: { type: 'leaf', paneId: activeId },
+      panes: { [activeId]: activePane },
+      maximizedPaneId: null,
     });
   },
 }));

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -99,6 +99,79 @@ function removePaneFromTree(node: SplitNode, paneId: string): SplitNode | null {
   return { ...node, children: newChildren, flexes: normalizedFlexes };
 }
 
+function getPaneDepth(root: SplitNode, paneId: string): number {
+  const path = findPanePath(root, paneId);
+  return path ? path.length : 0;
+}
+
+function insertPaneIntoTree(
+  root: SplitNode,
+  targetPaneId: string,
+  newPaneId: string,
+  direction: 'horizontal' | 'vertical',
+  insertBefore: boolean = false
+): SplitNode | null {
+  const panePath = findPanePath(root, targetPaneId);
+  if (panePath === null) return null;
+
+  // Navigate to the actual parent branch
+  let actualParent: SplitNode | null = root;
+  for (let i = 0; i < panePath.length - 1; i++) {
+    if (actualParent?.type !== 'branch') {
+      actualParent = null;
+      break;
+    }
+    actualParent = actualParent.children[panePath[i]];
+  }
+
+  if (
+    actualParent?.type === 'branch' &&
+    actualParent.axis === direction &&
+    panePath.length > 0
+  ) {
+    // Parent axis matches: insert new pane as a sibling
+    const childIdx = panePath[panePath.length - 1];
+    const newChildren = [...actualParent.children];
+    const newFlexes = [...actualParent.flexes];
+
+    const currentFlex = newFlexes[childIdx];
+    newFlexes[childIdx] = currentFlex / 2;
+
+    const insertIdx = insertBefore ? childIdx : childIdx + 1;
+    newChildren.splice(insertIdx, 0, { type: 'leaf', paneId: newPaneId });
+    newFlexes.splice(insertIdx, 0, currentFlex / 2);
+
+    const updatedParent: SplitNode = {
+      ...actualParent,
+      children: newChildren,
+      flexes: newFlexes,
+    };
+
+    if (panePath.length === 1) {
+      return updatedParent;
+    } else {
+      const pathToParent = panePath.slice(0, -1);
+      return replaceNodeAtPath(root, pathToParent, () => updatedParent);
+    }
+  } else {
+    // Different axis or root leaf: wrap in a new branch
+    const leafExisting: SplitNode = { type: 'leaf', paneId: targetPaneId };
+    const leafNew: SplitNode = { type: 'leaf', paneId: newPaneId };
+    const children = insertBefore
+      ? [leafNew, leafExisting]
+      : [leafExisting, leafNew];
+
+    const newBranch: SplitNode = {
+      type: 'branch',
+      axis: direction,
+      children,
+      flexes: [0.5, 0.5],
+    };
+
+    return replaceNodeAtPath(root, panePath, () => newBranch);
+  }
+}
+
 // ─── Initial State ──────────────────────────────────────────────────────────
 
 const initialPaneId = generatePaneId();
@@ -162,6 +235,9 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     const pane = state.panes[paneId];
     if (!pane) return;
 
+    // Limit splitting to depth 2 (e.g. one horizontal, one vertical max)
+    if (getPaneDepth(state.rootNode, paneId) >= 2) return;
+
     const newPaneId = generatePaneId();
     const newPane: PaneState = {
       // Inherit active file from the source pane (like Zed)
@@ -170,74 +246,13 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       activeFileContent: pane.activeFileContent,
     };
 
-    const panePath = findPanePath(state.rootNode, paneId);
-    if (panePath === null) return;
-
-    // Check if the parent branch has the same axis
-
-    // Navigate to the actual parent branch
-    let actualParent: SplitNode | null = state.rootNode;
-    for (let i = 0; i < panePath.length - 1; i++) {
-      if (actualParent?.type !== 'branch') {
-        actualParent = null;
-        break;
-      }
-      actualParent = actualParent.children[panePath[i]];
-    }
-
-    let newRoot: SplitNode;
-
-    if (
-      actualParent?.type === 'branch' &&
-      actualParent.axis === direction &&
-      panePath.length > 0
-    ) {
-      // Parent axis matches: insert new pane as a sibling
-      const childIdx = panePath[panePath.length - 1];
-      const newChildren = [...actualParent.children];
-      const newFlexes = [...actualParent.flexes];
-
-      // Split the current child's flex in half
-      const currentFlex = newFlexes[childIdx];
-      newFlexes[childIdx] = currentFlex / 2;
-      newChildren.splice(childIdx + 1, 0, {
-        type: 'leaf',
-        paneId: newPaneId,
-      });
-      newFlexes.splice(childIdx + 1, 0, currentFlex / 2);
-
-      const updatedParent: SplitNode = {
-        ...actualParent,
-        children: newChildren,
-        flexes: newFlexes,
-      };
-
-      // Replace the parent in the tree
-      if (panePath.length === 1) {
-        // Parent is root
-        newRoot = updatedParent;
-      } else {
-        const pathToParent = panePath.slice(0, -1);
-        newRoot = replaceNodeAtPath(
-          state.rootNode,
-          pathToParent,
-          () => updatedParent
-        );
-      }
-    } else {
-      // Different axis or root leaf: wrap in a new branch
-      const newBranch: SplitNode = {
-        type: 'branch',
-        axis: direction,
-        children: [
-          { type: 'leaf', paneId },
-          { type: 'leaf', paneId: newPaneId },
-        ],
-        flexes: [0.5, 0.5],
-      };
-
-      newRoot = replaceNodeAtPath(state.rootNode, panePath, () => newBranch);
-    }
+    const newRoot = insertPaneIntoTree(
+      state.rootNode,
+      paneId,
+      newPaneId,
+      direction
+    );
+    if (!newRoot) return;
 
     set({
       rootNode: newRoot,
@@ -254,13 +269,29 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     insertBefore = false
   ) => {
     const state = get();
-    if (!state.panes[paneId]) return;
+    const targetPane = state.panes[paneId];
+    if (!targetPane) return;
+
+    // Check if target pane is empty (or only has welcome tab). If so, just open the file there.
+    if (
+      targetPane.openFiles.length === 0 ||
+      (targetPane.openFiles.length === 1 &&
+        targetPane.openFiles[0] === 'welcome')
+    ) {
+      if (sourcePaneId && sourcePaneId !== paneId) {
+        get().paneCloseFile(sourcePaneId, fileId);
+      }
+      get().paneSelectFile(paneId, fileId);
+      return;
+    }
 
     // First, close the file from the source pane (if different pane)
     const updatedPanes = { ...state.panes };
-    if (sourcePaneId !== paneId && updatedPanes[sourcePaneId]) {
+    if (sourcePaneId && sourcePaneId !== paneId && updatedPanes[sourcePaneId]) {
       const srcPane = updatedPanes[sourcePaneId];
-      const newOpenFiles = srcPane.openFiles.filter((id) => id !== fileId);
+      const newOpenFiles = srcPane.openFiles.filter(
+        (id: string) => id !== fileId
+      );
       const wasActive = srcPane.activeFileId === fileId;
       updatedPanes[sourcePaneId] = {
         ...srcPane,
@@ -299,28 +330,25 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
         .catch(console.error);
     }
 
-    // Build tree: find the target pane and create a branch
-    const panePath = findPanePath(state.rootNode, paneId);
-    if (panePath === null) return;
+    // Limit splitting to depth 2
+    if (getPaneDepth(state.rootNode, paneId) >= 2) {
+      // If we can't split, just move/open the file in the target pane
+      if (sourcePaneId && sourcePaneId !== paneId) {
+        get().paneCloseFile(sourcePaneId, fileId);
+      }
+      get().paneSelectFile(paneId, fileId);
+      return;
+    }
 
-    const leafExisting: SplitNode = { type: 'leaf', paneId };
-    const leafNew: SplitNode = { type: 'leaf', paneId: newPaneId };
-    const children = insertBefore
-      ? [leafNew, leafExisting]
-      : [leafExisting, leafNew];
-
-    const newBranch: SplitNode = {
-      type: 'branch',
-      axis: direction,
-      children,
-      flexes: [0.5, 0.5],
-    };
-
-    const newRoot = replaceNodeAtPath(
+    // Build tree using helper
+    const newRoot = insertPaneIntoTree(
       state.rootNode,
-      panePath,
-      () => newBranch
+      paneId,
+      newPaneId,
+      direction,
+      insertBefore
     );
+    if (!newRoot) return;
 
     set({
       rootNode: newRoot,

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -113,6 +113,13 @@ interface SplitStoreState {
 
   // Tree actions
   splitPane: (paneId: string, direction: 'horizontal' | 'vertical') => void;
+  splitPaneWithFile: (
+    paneId: string,
+    direction: 'horizontal' | 'vertical',
+    fileId: string,
+    sourcePaneId: string,
+    insertBefore?: boolean
+  ) => void;
   closePane: (paneId: string) => void;
   setActivePaneId: (paneId: string) => void;
   setSplitRatio: (
@@ -235,6 +242,89 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
     set({
       rootNode: newRoot,
       panes: { ...state.panes, [newPaneId]: newPane },
+      activePaneId: newPaneId,
+    });
+  },
+
+  splitPaneWithFile: (
+    paneId,
+    direction,
+    fileId,
+    sourcePaneId,
+    insertBefore = false
+  ) => {
+    const state = get();
+    if (!state.panes[paneId]) return;
+
+    // First, close the file from the source pane (if different pane)
+    const updatedPanes = { ...state.panes };
+    if (sourcePaneId !== paneId && updatedPanes[sourcePaneId]) {
+      const srcPane = updatedPanes[sourcePaneId];
+      const newOpenFiles = srcPane.openFiles.filter((id) => id !== fileId);
+      const wasActive = srcPane.activeFileId === fileId;
+      updatedPanes[sourcePaneId] = {
+        ...srcPane,
+        openFiles: newOpenFiles,
+        activeFileId: wasActive
+          ? (newOpenFiles[newOpenFiles.length - 1] ?? null)
+          : srcPane.activeFileId,
+        activeFileContent: wasActive ? '' : srcPane.activeFileContent,
+      };
+    }
+
+    // Create the new pane with the dropped file
+    const newPaneId = generatePaneId();
+    const newPane: PaneState = {
+      activeFileId: fileId,
+      openFiles: [fileId],
+      activeFileContent: '',
+    };
+
+    // Load file content
+    const appState = useAppStore.getState();
+    const file = appState.findFile(fileId);
+    if (file?.path) {
+      invoke<string>('read_note', { path: file.path })
+        .then((content) => {
+          const current = get().panes[newPaneId];
+          if (current?.activeFileId === fileId) {
+            set({
+              panes: {
+                ...get().panes,
+                [newPaneId]: { ...current, activeFileContent: content },
+              },
+            });
+          }
+        })
+        .catch(console.error);
+    }
+
+    // Build tree: find the target pane and create a branch
+    const panePath = findPanePath(state.rootNode, paneId);
+    if (panePath === null) return;
+
+    const leafExisting: SplitNode = { type: 'leaf', paneId };
+    const leafNew: SplitNode = { type: 'leaf', paneId: newPaneId };
+    const children = insertBefore
+      ? [leafNew, leafExisting]
+      : [leafExisting, leafNew];
+
+    const newBranch: SplitNode = {
+      type: 'branch',
+      axis: direction,
+      children,
+      flexes: [0.5, 0.5],
+    };
+
+    const newRoot = replaceNodeAtPath(
+      state.rootNode,
+      panePath,
+      () => newBranch
+    );
+
+    set({
+      rootNode: newRoot,
+      panes: { ...updatedPanes, [newPaneId]: newPane },
       activePaneId: newPaneId,
     });
   },

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -184,19 +184,26 @@ interface SplitStoreState {
   activePaneId: string;
   maximizedPaneId: string | null;
   newTabCounter: number;
+  isResizing: boolean;
 
   // Tree actions
-  splitPane: (paneId: string, direction: 'horizontal' | 'vertical') => void;
+  splitPane: (
+    paneId: string,
+    direction: 'horizontal' | 'vertical',
+    insertBefore?: boolean
+  ) => void;
   splitPaneWithFile: (
     paneId: string,
     direction: 'horizontal' | 'vertical',
     fileId: string,
-    sourcePaneId: string,
+    sourcePaneId?: string,
     insertBefore?: boolean
   ) => void;
   closePane: (paneId: string) => void;
   setActivePaneId: (paneId: string) => void;
   toggleMaximizePane: (paneId: string) => void;
+  setMaximizedPane: (paneId: string | null) => void;
+  setIsResizing: (isResizing: boolean) => void;
   setSplitRatio: (
     branchPath: number[],
     childIndex: number,
@@ -230,10 +237,11 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
   activePaneId: initialPaneId,
   maximizedPaneId: null,
   newTabCounter: 0,
+  isResizing: false,
 
   // ─── Tree Actions ───────────────────────────────────────────────────────
 
-  splitPane: (paneId, direction) => {
+  splitPane: (paneId, direction, insertBefore = false) => {
     const state = get();
     const pane = state.panes[paneId];
     if (!pane) return;
@@ -253,7 +261,8 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
       state.rootNode,
       paneId,
       newPaneId,
-      direction
+      direction,
+      insertBefore
     );
     if (!newRoot) return;
 
@@ -406,6 +415,21 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
 
   setActivePaneId: (paneId) => {
     set({ activePaneId: paneId });
+  },
+
+  toggleMaximizePane: (paneId) => {
+    const state = get();
+    set({
+      maximizedPaneId: state.maximizedPaneId === paneId ? null : paneId,
+    });
+  },
+
+  setMaximizedPane: (paneId) => {
+    set({ maximizedPaneId: paneId });
+  },
+
+  setIsResizing: (isResizing) => {
+    set({ isResizing });
   },
 
   setSplitRatio: (branchPath, childIndex, delta) => {
@@ -878,11 +902,6 @@ export const useSplitStore = create<SplitStoreState>()((set, get) => ({
         }
       }, 50);
     }
-  },
-
-  toggleMaximizePane: (paneId) => {
-    const { maximizedPaneId } = get();
-    set({ maximizedPaneId: maximizedPaneId === paneId ? null : paneId });
   },
 
   // ─── Init/Reset ─────────────────────────────────────────────────────────

--- a/src/store/useSplitStore.ts
+++ b/src/store/useSplitStore.ts
@@ -1,0 +1,750 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import { useAppStore } from './useAppStore';
+import { registerSplitStore } from './storeBridge';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface PaneState {
+  activeFileId: string | null;
+  openFiles: string[];
+  activeFileContent: string;
+}
+
+export type SplitNode =
+  | { type: 'leaf'; paneId: string }
+  | {
+      type: 'branch';
+      axis: 'horizontal' | 'vertical';
+      children: SplitNode[];
+      flexes: number[];
+    };
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let paneCounter = 0;
+function generatePaneId(): string {
+  return `pane-${++paneCounter}`;
+}
+
+function createEmptyPane(): PaneState {
+  return {
+    activeFileId: null,
+    openFiles: [],
+    activeFileContent: '',
+  };
+}
+
+/** Collect all pane IDs in the tree */
+function collectPaneIds(node: SplitNode): string[] {
+  if (node.type === 'leaf') return [node.paneId];
+  return node.children.flatMap(collectPaneIds);
+}
+
+/** Replace a node in the tree identified by path */
+function replaceNodeAtPath(
+  root: SplitNode,
+  path: number[],
+  replacer: (node: SplitNode) => SplitNode
+): SplitNode {
+  if (path.length === 0) return replacer(root);
+  if (root.type !== 'branch') return root;
+
+  const [head, ...rest] = path;
+  const newChildren = root.children.map((child, i) =>
+    i === head ? replaceNodeAtPath(child, rest, replacer) : child
+  );
+  return { ...root, children: newChildren };
+}
+
+/** Find the path from root to a paneId */
+function findPanePath(node: SplitNode, paneId: string): number[] | null {
+  if (node.type === 'leaf') {
+    return node.paneId === paneId ? [] : null;
+  }
+  for (let i = 0; i < node.children.length; i++) {
+    const subPath = findPanePath(node.children[i], paneId);
+    if (subPath !== null) return [i, ...subPath];
+  }
+  return null;
+}
+
+/**
+ * Remove a pane from the tree and collapse single-child branches.
+ * Returns the new root node, or null if the tree is empty.
+ */
+function removePaneFromTree(node: SplitNode, paneId: string): SplitNode | null {
+  if (node.type === 'leaf') {
+    return node.paneId === paneId ? null : node;
+  }
+
+  const newChildren: SplitNode[] = [];
+  const newFlexes: number[] = [];
+
+  for (let i = 0; i < node.children.length; i++) {
+    const result = removePaneFromTree(node.children[i], paneId);
+    if (result !== null) {
+      newChildren.push(result);
+      newFlexes.push(node.flexes[i]);
+    }
+  }
+
+  if (newChildren.length === 0) return null;
+  if (newChildren.length === 1) return newChildren[0]; // Collapse single-child
+
+  // Normalize flexes
+  const total = newFlexes.reduce((a, b) => a + b, 0);
+  const normalizedFlexes = newFlexes.map((f) => f / total);
+
+  return { ...node, children: newChildren, flexes: normalizedFlexes };
+}
+
+// ─── Initial State ──────────────────────────────────────────────────────────
+
+const initialPaneId = generatePaneId();
+
+// ─── Store ──────────────────────────────────────────────────────────────────
+
+interface SplitStoreState {
+  rootNode: SplitNode;
+  panes: Record<string, PaneState>;
+  activePaneId: string;
+  newTabCounter: number;
+
+  // Tree actions
+  splitPane: (paneId: string, direction: 'horizontal' | 'vertical') => void;
+  closePane: (paneId: string) => void;
+  setActivePaneId: (paneId: string) => void;
+  setSplitRatio: (
+    branchPath: number[],
+    childIndex: number,
+    delta: number
+  ) => void;
+  resetFlexes: (branchPath: number[]) => void;
+
+  // Pane-scoped file actions
+  paneSelectFile: (paneId: string, fileId: string) => void;
+  paneCloseFile: (paneId: string, fileId: string) => void;
+  paneSetActiveContent: (paneId: string, content: string) => void;
+  paneCreateNewTab: (paneId: string) => void;
+  paneCloseOtherFiles: (paneId: string, fileId: string) => void;
+  paneCloseAllFiles: (paneId: string) => void;
+  paneUpdateFileContent: (
+    paneId: string,
+    fileId: string,
+    content: string
+  ) => void;
+  paneOpenFileInNewTab: (paneId: string, fileId: string) => void;
+  paneOpenSystemTab: (paneId: string, tabId: string) => void;
+  paneCloseFileOnly: (paneId: string, fileId: string) => void;
+
+  // Init/reset
+  resetToSinglePane: () => void;
+}
+
+export const useSplitStore = create<SplitStoreState>()((set, get) => ({
+  rootNode: { type: 'leaf', paneId: initialPaneId },
+  panes: { [initialPaneId]: createEmptyPane() },
+  activePaneId: initialPaneId,
+  newTabCounter: 0,
+
+  // ─── Tree Actions ───────────────────────────────────────────────────────
+
+  splitPane: (paneId, direction) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newPaneId = generatePaneId();
+    const newPane: PaneState = {
+      // Inherit active file from the source pane (like Zed)
+      activeFileId: pane.activeFileId,
+      openFiles: pane.activeFileId ? [pane.activeFileId] : [],
+      activeFileContent: pane.activeFileContent,
+    };
+
+    const panePath = findPanePath(state.rootNode, paneId);
+    if (panePath === null) return;
+
+    // Check if the parent branch has the same axis
+
+    // Navigate to the actual parent branch
+    let actualParent: SplitNode | null = state.rootNode;
+    for (let i = 0; i < panePath.length - 1; i++) {
+      if (actualParent?.type !== 'branch') {
+        actualParent = null;
+        break;
+      }
+      actualParent = actualParent.children[panePath[i]];
+    }
+
+    let newRoot: SplitNode;
+
+    if (
+      actualParent?.type === 'branch' &&
+      actualParent.axis === direction &&
+      panePath.length > 0
+    ) {
+      // Parent axis matches: insert new pane as a sibling
+      const childIdx = panePath[panePath.length - 1];
+      const newChildren = [...actualParent.children];
+      const newFlexes = [...actualParent.flexes];
+
+      // Split the current child's flex in half
+      const currentFlex = newFlexes[childIdx];
+      newFlexes[childIdx] = currentFlex / 2;
+      newChildren.splice(childIdx + 1, 0, {
+        type: 'leaf',
+        paneId: newPaneId,
+      });
+      newFlexes.splice(childIdx + 1, 0, currentFlex / 2);
+
+      const updatedParent: SplitNode = {
+        ...actualParent,
+        children: newChildren,
+        flexes: newFlexes,
+      };
+
+      // Replace the parent in the tree
+      if (panePath.length === 1) {
+        // Parent is root
+        newRoot = updatedParent;
+      } else {
+        const pathToParent = panePath.slice(0, -1);
+        newRoot = replaceNodeAtPath(
+          state.rootNode,
+          pathToParent,
+          () => updatedParent
+        );
+      }
+    } else {
+      // Different axis or root leaf: wrap in a new branch
+      const newBranch: SplitNode = {
+        type: 'branch',
+        axis: direction,
+        children: [
+          { type: 'leaf', paneId },
+          { type: 'leaf', paneId: newPaneId },
+        ],
+        flexes: [0.5, 0.5],
+      };
+
+      newRoot = replaceNodeAtPath(state.rootNode, panePath, () => newBranch);
+    }
+
+    set({
+      rootNode: newRoot,
+      panes: { ...state.panes, [newPaneId]: newPane },
+      activePaneId: newPaneId,
+    });
+  },
+
+  closePane: (paneId) => {
+    const state = get();
+    const allPanes = collectPaneIds(state.rootNode);
+
+    // Don't close the last pane
+    if (allPanes.length <= 1) return;
+
+    const newRoot = removePaneFromTree(state.rootNode, paneId);
+    if (!newRoot) return;
+
+    // Remove pane state
+    const newPanes = { ...state.panes };
+    delete newPanes[paneId];
+
+    // If the closed pane was active, pick a neighbor
+    let newActivePaneId = state.activePaneId;
+    if (state.activePaneId === paneId) {
+      const remainingPanes = collectPaneIds(newRoot);
+      newActivePaneId = remainingPanes[0] || state.activePaneId;
+    }
+
+    set({
+      rootNode: newRoot,
+      panes: newPanes,
+      activePaneId: newActivePaneId,
+    });
+  },
+
+  setActivePaneId: (paneId) => {
+    set({ activePaneId: paneId });
+  },
+
+  setSplitRatio: (branchPath, childIndex, delta) => {
+    const state = get();
+
+    const updateBranch = (node: SplitNode): SplitNode => {
+      let current = node;
+      for (const idx of branchPath) {
+        if (current.type !== 'branch') return node;
+        current = current.children[idx];
+      }
+
+      if (current.type !== 'branch') return node;
+
+      const branch = current;
+      const newFlexes = [...branch.flexes];
+      const minFlex = 0.1; // Minimum 10%
+
+      // Adjust adjacent flexes
+      const left = newFlexes[childIndex];
+      const right = newFlexes[childIndex + 1];
+      const total = left + right;
+
+      let newLeft = left + delta;
+      let newRight = right - delta;
+
+      // Clamp
+      if (newLeft < minFlex * total) {
+        newLeft = minFlex * total;
+        newRight = total - newLeft;
+      }
+      if (newRight < minFlex * total) {
+        newRight = minFlex * total;
+        newLeft = total - newRight;
+      }
+
+      newFlexes[childIndex] = newLeft;
+      newFlexes[childIndex + 1] = newRight;
+
+      const updatedBranch: SplitNode = { ...branch, flexes: newFlexes };
+
+      // Replace in tree
+      if (branchPath.length === 0) return updatedBranch;
+      return replaceNodeAtPath(node, branchPath, () => updatedBranch);
+    };
+
+    set({ rootNode: updateBranch(state.rootNode) });
+  },
+
+  resetFlexes: (branchPath) => {
+    const state = get();
+
+    let target: SplitNode = state.rootNode;
+    for (const idx of branchPath) {
+      if (target.type !== 'branch') return;
+      target = target.children[idx];
+    }
+    if (target.type !== 'branch') return;
+
+    const n = target.children.length;
+    const equalFlexes = Array(n).fill(1 / n);
+    const updatedBranch: SplitNode = { ...target, flexes: equalFlexes };
+
+    const newRoot =
+      branchPath.length === 0
+        ? updatedBranch
+        : replaceNodeAtPath(state.rootNode, branchPath, () => updatedBranch);
+
+    set({ rootNode: newRoot });
+  },
+
+  // ─── Pane-Scoped File Actions ───────────────────────────────────────────
+
+  paneSelectFile: (paneId, fileId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    // Handle blank tabs
+    if (fileId.startsWith('new-tab-')) {
+      const newPanes = { ...state.panes };
+      if (pane.activeFileId === 'welcome') {
+        newPanes[paneId] = {
+          ...pane,
+          activeFileId: fileId,
+          activeFileContent: '',
+          openFiles: [fileId],
+        };
+      } else {
+        newPanes[paneId] = {
+          ...pane,
+          activeFileId: fileId,
+          activeFileContent: '',
+        };
+      }
+      set({ panes: newPanes, activePaneId: paneId });
+      return;
+    }
+
+    // Handle system tabs
+    if (fileId.startsWith('cinder-')) {
+      const newPanes = { ...state.panes };
+      const openFiles = pane.openFiles.includes(fileId)
+        ? pane.openFiles
+        : pane.activeFileId &&
+            (pane.activeFileId === 'welcome' ||
+              pane.activeFileId.startsWith('new-tab-'))
+          ? pane.openFiles.map((id) => (id === pane.activeFileId ? fileId : id))
+          : [...pane.openFiles, fileId];
+
+      newPanes[paneId] = {
+        ...pane,
+        activeFileId: fileId,
+        activeFileContent: '',
+        openFiles,
+      };
+      set({ panes: newPanes, activePaneId: paneId });
+      return;
+    }
+
+    // Regular file
+    const appStore = useAppStore.getState();
+    const file = appStore.findFile(fileId);
+    if (!file || file.type !== 'file') return;
+
+    const filePath = file.path;
+
+    // Determine new openFiles
+    let newOpenFiles: string[];
+    if (
+      pane.activeFileId &&
+      (pane.activeFileId.startsWith('new-tab-') ||
+        pane.activeFileId === 'welcome')
+    ) {
+      // Replace the blank/welcome tab
+      newOpenFiles = pane.openFiles.map((id) =>
+        id === pane.activeFileId ? fileId : id
+      );
+    } else {
+      newOpenFiles = pane.openFiles.includes(fileId)
+        ? pane.openFiles
+        : [...pane.openFiles, fileId];
+    }
+
+    // Update pane state immediately
+    const newPanes = { ...state.panes };
+    newPanes[paneId] = {
+      ...pane,
+      activeFileId: fileId,
+      activeFileContent: '',
+      openFiles: newOpenFiles,
+    };
+    set({ panes: newPanes, activePaneId: paneId });
+
+    // Read content from disk
+    if (filePath) {
+      invoke<string>('read_note', { path: filePath })
+        .then((content) => {
+          const currentState = get();
+          const currentPane = currentState.panes[paneId];
+          if (currentPane?.activeFileId === fileId) {
+            const updatedPanes = { ...currentState.panes };
+            updatedPanes[paneId] = {
+              ...currentPane,
+              activeFileContent: content,
+            };
+            set({ panes: updatedPanes });
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to read file:', err);
+          const currentState = get();
+          const currentPane = currentState.panes[paneId];
+          if (currentPane?.activeFileId === fileId) {
+            const updatedPanes = { ...currentState.panes };
+            updatedPanes[paneId] = {
+              ...currentPane,
+              activeFileContent: `Error loading file: ${err}`,
+            };
+            set({ panes: updatedPanes });
+          }
+        });
+    } else {
+      // In-memory fallback
+      const newPanesUpdate = { ...get().panes };
+      newPanesUpdate[paneId] = {
+        ...newPanesUpdate[paneId],
+        activeFileContent: file.content || '',
+      };
+      set({ panes: newPanesUpdate });
+    }
+  },
+
+  paneOpenFileInNewTab: (paneId, fileId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const appStore = useAppStore.getState();
+    const file = appStore.findFile(fileId);
+    if (!file || file.type !== 'file') return;
+
+    const filePath = file.path;
+
+    let newOpenFiles: string[];
+    if (
+      pane.activeFileId &&
+      (pane.activeFileId.startsWith('new-tab-') ||
+        pane.activeFileId === 'welcome')
+    ) {
+      newOpenFiles = pane.openFiles.map((id) =>
+        id === pane.activeFileId ? fileId : id
+      );
+    } else {
+      newOpenFiles = pane.openFiles.includes(fileId)
+        ? pane.openFiles
+        : [...pane.openFiles, fileId];
+    }
+
+    const newPanes = { ...state.panes };
+    newPanes[paneId] = {
+      ...pane,
+      activeFileId: fileId,
+      activeFileContent: '',
+      openFiles: newOpenFiles,
+    };
+    set({ panes: newPanes, activePaneId: paneId });
+
+    if (filePath) {
+      invoke<string>('read_note', { path: filePath })
+        .then((content) => {
+          const currentState = get();
+          const currentPane = currentState.panes[paneId];
+          if (currentPane?.activeFileId === fileId) {
+            const updatedPanes = { ...currentState.panes };
+            updatedPanes[paneId] = {
+              ...currentPane,
+              activeFileContent: content,
+            };
+            set({ panes: updatedPanes });
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to read file:', err);
+        });
+    } else {
+      const updPanes = { ...get().panes };
+      updPanes[paneId] = {
+        ...updPanes[paneId],
+        activeFileContent: file.content || '',
+      };
+      set({ panes: updPanes });
+    }
+  },
+
+  paneOpenSystemTab: (paneId, tabId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    let newOpenFiles: string[];
+    if (pane.openFiles.includes(tabId)) {
+      newOpenFiles = pane.openFiles;
+    } else if (
+      pane.activeFileId &&
+      (pane.activeFileId === 'welcome' ||
+        pane.activeFileId.startsWith('new-tab-'))
+    ) {
+      newOpenFiles = pane.openFiles.map((id) =>
+        id === pane.activeFileId ? tabId : id
+      );
+    } else {
+      newOpenFiles = [...pane.openFiles, tabId];
+    }
+
+    const newPanes = { ...state.panes };
+    newPanes[paneId] = {
+      ...pane,
+      activeFileId: tabId,
+      activeFileContent: '',
+      openFiles: newOpenFiles,
+    };
+    set({ panes: newPanes, activePaneId: paneId });
+  },
+
+  paneCloseFile: (paneId, fileId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newOpenFiles = pane.openFiles.filter((id) => id !== fileId);
+    const newPanes = { ...state.panes };
+
+    if (pane.activeFileId === fileId) {
+      const nextActive =
+        newOpenFiles.length > 0 ? newOpenFiles[newOpenFiles.length - 1] : null;
+
+      if (nextActive) {
+        // Set the new active file, then trigger content load
+        newPanes[paneId] = {
+          ...pane,
+          activeFileId: nextActive,
+          activeFileContent: '',
+          openFiles: newOpenFiles,
+        };
+        set({ panes: newPanes });
+        // Trigger content load for the next active file
+        get().paneSelectFile(paneId, nextActive);
+      } else {
+        newPanes[paneId] = {
+          ...pane,
+          activeFileId: null,
+          activeFileContent: '',
+          openFiles: newOpenFiles,
+        };
+        set({ panes: newPanes });
+      }
+    } else {
+      newPanes[paneId] = {
+        ...pane,
+        openFiles: newOpenFiles,
+      };
+      set({ panes: newPanes });
+    }
+  },
+
+  /** Close a file from openFiles without switching active file content */
+  paneCloseFileOnly: (paneId, fileId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newOpenFiles = pane.openFiles.filter((id) => id !== fileId);
+    const newPanes = { ...state.panes };
+    newPanes[paneId] = { ...pane, openFiles: newOpenFiles };
+    set({ panes: newPanes });
+  },
+
+  paneSetActiveContent: (paneId, content) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newPanes = { ...state.panes };
+    newPanes[paneId] = { ...pane, activeFileContent: content };
+    set({ panes: newPanes });
+  },
+
+  paneCreateNewTab: (paneId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newCounter = state.newTabCounter + 1;
+    const newTabId = `new-tab-${newCounter}`;
+
+    const newPanes = { ...state.panes };
+
+    if (pane.activeFileId === 'welcome') {
+      newPanes[paneId] = {
+        activeFileId: newTabId,
+        openFiles: [newTabId],
+        activeFileContent: '',
+      };
+    } else {
+      newPanes[paneId] = {
+        ...pane,
+        activeFileId: newTabId,
+        openFiles: [...pane.openFiles, newTabId],
+        activeFileContent: '',
+      };
+    }
+
+    set({ panes: newPanes, newTabCounter: newCounter });
+
+    // Trigger rename mode in the app store
+    useAppStore.getState().setRenamingFileId(newTabId, 'editor');
+  },
+
+  paneCloseOtherFiles: (paneId, fileId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newPanes = { ...state.panes };
+    const hasFile = pane.openFiles.includes(fileId);
+
+    newPanes[paneId] = {
+      ...pane,
+      openFiles: hasFile ? [fileId] : [],
+      activeFileId: hasFile ? fileId : null,
+      activeFileContent:
+        pane.activeFileId === fileId ? pane.activeFileContent : '',
+    };
+    set({ panes: newPanes });
+
+    // Load content if switching to a different file
+    if (hasFile && pane.activeFileId !== fileId) {
+      get().paneSelectFile(paneId, fileId);
+    }
+  },
+
+  paneCloseAllFiles: (paneId) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    const newPanes = { ...state.panes };
+    newPanes[paneId] = {
+      ...pane,
+      openFiles: [],
+      activeFileId: null,
+      activeFileContent: '',
+    };
+    set({ panes: newPanes });
+  },
+
+  paneUpdateFileContent: (paneId, fileId, content) => {
+    const state = get();
+    const pane = state.panes[paneId];
+    if (!pane) return;
+
+    // Update pane content
+    if (pane.activeFileId === fileId) {
+      const newPanes = { ...state.panes };
+      newPanes[paneId] = { ...pane, activeFileContent: content };
+      set({ panes: newPanes });
+    }
+
+    // Delegate disk I/O and file tree updates to app store
+    useAppStore.getState().updateFileContent(fileId, content);
+
+    // If updateFileContent created a real file from a new-tab-*, sync the pane
+    if (fileId.startsWith('new-tab-')) {
+      // Wait a tick for the app store to update, then check for the new file ID
+      setTimeout(() => {
+        const appState = useAppStore.getState();
+        const currentState = get();
+        const currentPane = currentState.panes[paneId];
+        if (!currentPane) return;
+
+        // Check if the app store's file tree has a file that replaced this tab
+        // The updateFileContent in useAppStore replaces the new-tab-* ID with a real path
+        // We need to sync that change to the pane
+        const newActiveId = appState.activeFileId;
+        if (
+          newActiveId &&
+          newActiveId !== fileId &&
+          currentPane.activeFileId === fileId
+        ) {
+          const newPanes = { ...currentState.panes };
+          newPanes[paneId] = {
+            ...currentPane,
+            activeFileId: newActiveId,
+            openFiles: currentPane.openFiles.map((id) =>
+              id === fileId ? newActiveId : id
+            ),
+          };
+          set({ panes: newPanes });
+        }
+      }, 50);
+    }
+  },
+
+  // ─── Init/Reset ─────────────────────────────────────────────────────────
+
+  resetToSinglePane: () => {
+    const newPaneId = generatePaneId();
+    set({
+      rootNode: { type: 'leaf', paneId: newPaneId },
+      panes: { [newPaneId]: createEmptyPane() },
+      activePaneId: newPaneId,
+      newTabCounter: 0,
+    });
+  },
+}));
+
+// Register with bridge for cross-store access
+registerSplitStore(useSplitStore);

--- a/src/util/dragContext.ts
+++ b/src/util/dragContext.ts
@@ -1,0 +1,27 @@
+/**
+ * Module-level drag context.
+ *
+ * HTML5 Drag & Drop blocks `dataTransfer.getData()` during `dragover` events
+ * (only available in `drop`). This module stores the current drag payload so
+ * drop targets can inspect what is being dragged and decide whether to show
+ * overlay indicators.
+ */
+
+export interface DragPayload {
+  /** The file/node ID being dragged */
+  fileId: string;
+  /** Source pane ID if dragged from a tab, null if from sidebar */
+  sourcePaneId: string | null;
+  /** Whether the dragged item is a folder */
+  isFolder: boolean;
+}
+
+let currentDrag: DragPayload | null = null;
+
+export function setCurrentDrag(payload: DragPayload | null) {
+  currentDrag = payload;
+}
+
+export function getCurrentDrag(): DragPayload | null {
+  return currentDrag;
+}


### PR DESCRIPTION
# feat: Zed-style split screen panes

Adds split-screen editing with up to 4 panes (quadrant layout), supporting drag-to-split from tabs and sidebar, smooth resizing, and pane maximizing.

## Changes

### Split Pane Architecture

- **New `useSplitStore`** -- manages a binary tree of panes (`SplitNode`) with flexible layout axes (horizontal/vertical). Each pane holds its own `openFiles`, `activeFileId`, and `activeFileContent` independently.
- **`SplitContainer`** -- recursive renderer that walks the split tree and lays out panes with CSS flex.
- **`SplitResizeHandle`** -- draggable divider between panes with double-click-to-reset and smooth cursor feedback.
- **`storeBridge`** -- wires cross-store events so file renames/deletes in `useAppStore` propagate to all split panes.

### Drag-to-Split

- Drag a tab or sidebar file to the **edge** of any pane to split in that direction (left/right/top/bottom).
- Drop in the **center** to move/open the file without splitting.
- Visual overlay highlights the target zone during drag.

### Overlay Guards

The split overlay is now suppressed when it would be misleading:

| Scenario | Behavior |
|---|---|
| Dragging a **folder** | No overlay -- folders cannot open as tabs |
| Dragging a tab **within the same pane** | No overlay -- no-op |
| Already at **4 panes** (max) | Center-only -- edge splits are blocked |

Implemented via a shared [`dragContext`](src/util/dragContext.ts) module since browsers block `dataTransfer.getData()` during `dragover` events.

### Pane Maximizing

- Toggle button in the tab bar to maximize/restore a single pane (hides all others temporarily).

### Keyboard Shortcuts

- Split shortcuts integrated into the existing shortcut system.

### Traffic Light Fix (macOS)

- The 84px spacer for macOS window controls now only renders on the **leftmost pane**, fixing a bug where every pane had the padding when the sidebar was hidden.

### Refactors

- Legacy `welcome` tab logic replaced with an empty-state fallback.
- File state management (`openFiles`, `activeFileId`, `activeFileContent`) moved from `useAppStore` to `useSplitStore` to support per-pane state.

## Files Changed

| File | Summary |
|---|---|
| `src/store/useSplitStore.ts` | **New.** Split tree state, pane CRUD, file actions, 4-pane limit |
| `src/store/storeBridge.ts` | **New.** Cross-store event propagation |
| `src/util/dragContext.ts` | **New.** Shared drag payload for overlay guards |
| `src/components/layout/editor/SplitContainer.tsx` | **New.** Recursive split layout renderer |
| `src/components/layout/editor/SplitResizeHandle.tsx` | **New.** Draggable resize divider |
| `src/components/layout/editor/EditorPane.tsx` | Drop zone detection, overlay rendering, drag guards |
| `src/components/layout/editor/EditorTabs.tsx` | Per-pane tabs, drag context, traffic light fix |
| `src/components/layout/editor/EditorHeader.tsx` | Accepts `paneId` prop |
| `src/components/layout/editor/Editor.tsx` | Accepts `paneId` prop |
| `src/components/layout/editor/EditorStatusBar.tsx` | Reads from split store |
| `src/components/layout/explorer/FileTreeItem.tsx` | Sets drag context on sidebar drag |
| `src/store/useAppStore.ts` | Removed per-file state (moved to split store) |
| `src/App.tsx` | Mounts `SplitContainer` instead of single `EditorPane` |
| `src/hooks/useKeyboardShortcuts.ts` | Added split shortcuts |
| `src/__tests__/components/EditorTabs.test.tsx` | Updated for split store API |

## Testing

- TypeScript typecheck passes
- ESLint + Prettier pass
- Manual testing: split, drag, maximize, resize, close panes, traffic lights
